### PR TITLE
image info: create parent dir

### DIFF
--- a/src/main/java/com/spotify/docker/BuildMojo.java
+++ b/src/main/java/com/spotify/docker/BuildMojo.java
@@ -203,6 +203,9 @@ public class BuildMojo extends AbstractDockerMojo {
 
     buildImage(docker, destination);
 
+    // Write image info file
+    final Path imageInfoPath = Paths.get(tagInfoFile);
+    Files.createDirectories(imageInfoPath.getParent());
     final FileOutputStream jsonOutput = new FileOutputStream(tagInfoFile);
     try {
       jsonOutput.write(new DockerBuildInformation(imageName).toJsonBytes());


### PR DESCRIPTION
If the project does not have any tests, target/test-classes will not be be created during the normal build process.
