### PR TITLE
use guava 12.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>10.0.1</version>
+        <version>12.0.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
docker-client needs at least guava 12 for
Lists.newCopyOnWriteArrayList().

Bumping to 17.0 seems to break guice which is used by the plexus
dependency injection.
