### PR TITLE
disable read timeouts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
-      <version>2.3.1</version>
+      <version>2.4.0</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe</groupId>

--- a/src/main/java/com/spotify/docker/AbstractDockerMojo.java
+++ b/src/main/java/com/spotify/docker/AbstractDockerMojo.java
@@ -34,6 +34,8 @@ import org.apache.maven.plugins.annotations.Parameter;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import static com.spotify.docker.client.DefaultDockerClient.NO_TIMEOUT;
+
 abstract class AbstractDockerMojo extends AbstractMojo {
 
   private static final String DEFAULT_DOCKER_HOST = "tcp://localhost:2375";
@@ -61,7 +63,10 @@ abstract class AbstractDockerMojo extends AbstractMojo {
   protected abstract void execute(final DockerClient dockerClient) throws Exception;
 
   protected DockerClient dockerClient() {
-    return new DefaultDockerClient(dockerHost());
+    return DefaultDockerClient.builder()
+        .uri(dockerHost())
+        .readTimeoutMillis(NO_TIMEOUT)
+        .build();
   }
 
   protected String dockerHost() {


### PR DESCRIPTION
Pulling, building, etc can take a long time, especially on workstations with docker running in virtualbox vm's etc. Disable read timeouts so that we behave more like the docker cli (which has no timeout) and provide a good user experience, especially first time they build an application image.
