### PR TITLE
Do not throw exception if not in git repo

### DIFF
--- a/src/main/java/com/spotify/docker/Git.java
+++ b/src/main/java/com/spotify/docker/Git.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker;
+
+import com.spotify.docker.client.DockerException;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.eclipse.jgit.api.Status;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+
+import java.io.IOException;
+
+public class Git {
+
+  private final Repository repo;
+
+  public Git() throws IOException {
+    final FileRepositoryBuilder builder = new FileRepositoryBuilder();
+    // scan environment GIT_* variables
+    builder.readEnvironment();
+    // scan up the file system tree
+    builder.findGitDir();
+    // if getGitDir is null, then we are not in a git repository
+    repo = builder.getGitDir() == null ? null : builder.build();
+
+  }
+
+  public boolean isRepository() {
+    return repo != null;
+  }
+
+  public String getCommitId()
+      throws GitAPIException, DockerException, IOException, MojoExecutionException {
+
+    if (repo == null) {
+      throw new MojoExecutionException(
+          "Cannot tag with git commit ID because directory not a git repo");
+    }
+
+    final StringBuilder result = new StringBuilder();
+
+    try {
+      // get the first 7 characters of the latest commit
+      final ObjectId head = repo.resolve("HEAD");
+      result.append(head.getName().substring(0, 7));
+      final org.eclipse.jgit.api.Git git = new org.eclipse.jgit.api.Git(repo);
+
+      // append first git tag we find
+      for (Ref gitTag : git.tagList().call()) {
+        if (gitTag.getObjectId().equals(head)) {
+          // name is refs/tag/name, so get substring after last slash
+          final String name = gitTag.getName();
+          result.append(".");
+          result.append(name.substring(name.lastIndexOf('/') + 1));
+          break;
+        }
+      }
+
+      // append '.DIRTY' if any files have been modified
+      final Status status = git.status().call();
+      if (status.hasUncommittedChanges()) {
+        result.append(".DIRTY");
+      }
+    } finally {
+      repo.close();
+    }
+
+    return result.length() == 0 ? null : result.toString();
+  }
+
+}

--- a/src/main/java/com/spotify/docker/TagMojo.java
+++ b/src/main/java/com/spotify/docker/TagMojo.java
@@ -101,7 +101,7 @@ public class TagMojo extends AbstractDockerMojo {
       if (tag != null) {
         getLog().warn("Ignoring useGitCommitId flag because tag is explicitly set in image name ");
       } else {
-        tag = Utils.getGitCommitId();
+        tag = new Git().getCommitId();
       }
     }
 

--- a/src/main/java/com/spotify/docker/Utils.java
+++ b/src/main/java/com/spotify/docker/Utils.java
@@ -27,13 +27,6 @@ import com.spotify.docker.client.DockerException;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
-import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.Status;
-import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.lib.ObjectId;
-import org.eclipse.jgit.lib.Ref;
-import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 
 import java.io.IOException;
 
@@ -64,50 +57,6 @@ public class Utils {
       throws MojoExecutionException, DockerException, IOException, InterruptedException {
       log.info("Pushing " + imageName);
       docker.push(imageName, new AnsiProgressHandler());
-  }
-
-  public static String getGitCommitId()
-      throws GitAPIException, DockerException, IOException, MojoExecutionException {
-
-    final FileRepositoryBuilder builder = new FileRepositoryBuilder();
-    builder.readEnvironment(); // scan environment GIT_* variables
-    builder.findGitDir(); // scan up the file system tree
-
-    if (builder.getGitDir() == null) {
-      throw new MojoExecutionException(
-          "Cannot tag with git commit ID because directory not a git repo");
-    }
-
-    final StringBuilder result = new StringBuilder();
-    final Repository repo = builder.build();
-
-    try {
-      // get the first 7 characters of the latest commit
-      final ObjectId head = repo.resolve("HEAD");
-      result.append(head.getName().substring(0, 7));
-      final Git git = new Git(repo);
-
-      // append first git tag we find
-      for (Ref gitTag : git.tagList().call()) {
-        if (gitTag.getObjectId().equals(head)) {
-          // name is refs/tag/name, so get substring after last slash
-          final String name = gitTag.getName();
-          result.append(".");
-          result.append(name.substring(name.lastIndexOf('/') + 1));
-          break;
-        }
-      }
-
-      // append '.DIRTY' if any files have been modified
-      final Status status = git.status().call();
-      if (status.hasUncommittedChanges()) {
-        result.append(".DIRTY");
-      }
-    } finally {
-      repo.close();
-    }
-
-    return result.length() == 0 ? null : result.toString();
   }
 
 }


### PR DESCRIPTION
This fixes an issue where the build mojo would throw an exception it
was run from a directory that wasn't a git repo. This would happen even
if you weren't using git commit IDs for tags.

We now throw an exception only if the useGitCommitId flag is true and
you're not in a git repo.
