### PR TITLE
Added support for Dockerfile's EXPOSE command

### DIFF
--- a/src/test/java/com/spotify/docker/BuildMojoTest.java
+++ b/src/test/java/com/spotify/docker/BuildMojoTest.java
@@ -65,7 +65,8 @@ public class BuildMojoTest extends AbstractMojoTestCase {
       "ADD resources/parent/child/child.xml resources/parent/child/child.xml",
       "ADD resources/parent/parent.xml resources/parent/parent.xml",
       "ADD copy2.json copy2.json",
-      "ENV FOO BAR"
+      "ENV FOO BAR",
+      "EXPOSE 8080 8081"
   );
 
   private static final List<String> PROFILE_GENERATED_DOCKERFILE = Arrays.asList(
@@ -77,7 +78,8 @@ public class BuildMojoTest extends AbstractMojoTestCase {
       "ENV ARTIFACT_ID docker-maven-plugin-test",
       "ENV FOO BAR",
       "ENV FOOZ BARZ",
-      "ENV PROPERTY_HELLO HELLO_VALUE"
+      "ENV PROPERTY_HELLO HELLO_VALUE",
+      "EXPOSE 8080 8081 8082"
   );
 
   @Override

--- a/src/test/resources/pom-build-generated-dockerfile.xml
+++ b/src/test/resources/pom-build-generated-dockerfile.xml
@@ -26,6 +26,10 @@
           <env>
             <FOO>BAR</FOO>
           </env>
+          <exposes>
+            <expose>8081</expose>
+            <expose>8080</expose>
+          </exposes>
           <cmd>-u</cmd>
           <!-- same copying tests as pom-build-docker-directory.xml, but make sure it works with auto-generated -->
           <!-- docker file. pom-build-docker-directory.xml specified its own docker directory-->

--- a/src/test/resources/pom-build-with-profile.xml
+++ b/src/test/resources/pom-build-with-profile.xml
@@ -26,6 +26,9 @@
           <env>
             <FOO>BAR</FOO>
           </env>
+          <exposes>
+            <expose>8082</expose>
+          </exposes>
         </configuration>
       </plugin>
     </plugins>

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -15,5 +15,6 @@ docker.build.profiles: {
             directory: src/test/resources
             includes: [pom-build-with-profile.xml]
         }]
+        exposes: [8080, 8081]
     }
 }


### PR DESCRIPTION
In the plugin's configuration element in the pom, you can now specify
which ports you would like to expose. For example:

``` xml
  <plugin>
    <groupId>com.spotify</groupId>
    <artifactId>spotify-docker-maven-plugin</artifactId>
    ...
    <configuration>
      ...
      <exposes>
        <expose>1234</expose>
      </exposes>
      ...
    </configuration>
  ...
  </plugin>
```

Note that you still need to publish that port when running the container
to make it available to the host machine (e.g. docker run -P=true ...)
