### PR TITLE
Use param name not user prop name when injecting imageName into session

### DIFF
--- a/src/main/java/com/spotify/docker/BuildMojo.java
+++ b/src/main/java/com/spotify/docker/BuildMojo.java
@@ -212,7 +212,7 @@ public class BuildMojo extends AbstractDockerMojo {
         imageName = repo + ":" + commitId;
       }
     }
-    session.getCurrentProject().getProperties().put("docker.imageName", imageName);
+    session.getCurrentProject().getProperties().put("imageName", imageName);
 
     final String destination = Paths.get(buildDirectory, "docker").toString();
     if (dockerDirectory == null) {


### PR DESCRIPTION
When you inject a variable into the session you need to use the parameter
name.
