### PR TITLE
Upgrade docker-client dep to 2.6.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
-      <version>2.4.1</version>
+      <version>2.6.4</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe</groupId>


### PR DESCRIPTION
This allows the plugin to talk HTTPS to docker server.
