### PR TITLE
Add support for HTTPS & Unix sockets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
-      <version>2.6.4</version>
+      <version>2.7.0</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe</groupId>


### PR DESCRIPTION
Respect the DOCKER_HOST and DOCKER_CERT_PATH environment variables and
connect to Docker instances over HTTPS or via Unix sockets.
