### PR TITLE
bump versions: jdk, guava, docker-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
-      <version>2.7.0</version>
+      <version>2.7.5</version>
     </dependency>
     <dependency>
       <groupId>com.typesafe</groupId>
@@ -174,7 +174,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>12.0.1</version>
+        <version>14.0.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -208,8 +208,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
I was trying to use 0.0.29 with remote api and it failed on linux:
`Execution default of goal com.spotify:docker-maven-plugin:0.0.29:build failed: Plugin com.spotify:docker-maven-plugin:0.0.29 or one of its dependencies could not be resolved: Could not find artifact de.gesellix:unix-socket-factory:jar:2014-09-26T18-52-33`

So I found: https://github.com/spotify/docker-client/issues/70
I've tried to override docker-client dependency in my pom and got guava incompatibility issue (required version of docker-client 2.7.5 is >=14). So I resorted to docker-maven-plugin modifications and got everything working.

Lets bump versions across the board! :)
