### PR TITLE
Set mtime of copied files to 0 to enable Docker cache

### DIFF
--- a/src/main/java/com/spotify/docker/BuildMojo.java
+++ b/src/main/java/com/spotify/docker/BuildMojo.java
@@ -53,6 +53,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.FileTime;
 import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.List;
@@ -564,6 +565,7 @@ public class BuildMojo extends AbstractDockerMojo {
         // ensure all directories exist because copy operation will fail if they don't
         Files.createDirectories(destPath.getParent());
         Files.copy(sourcePath, destPath, StandardCopyOption.REPLACE_EXISTING);
+        Files.setLastModifiedTime(destPath, FileTime.fromMillis(0));
         // file location relative to docker directory, used later to generate Dockerfile
         final Path relativePath = Paths.get(targetPath, included);
         copiedPaths.add(relativePath.toString());


### PR DESCRIPTION
The `copyResources` method always overwrites the files in the Docker context that are going to be copied. This is annoying because then the Docker cache is never triggered, since Docker hashes both the file contents and the mtime when determining what to cache.

Preserving the source mtime doesn't work because Git changes mtime all the time, which is annoying too.

I opted for setting the mtime to epoch + 0 instead, which might not be the cleanest solution, but it works.