### PR TITLE
Throw MojoExecutionException instead of NPE

### DIFF
--- a/src/main/java/com/spotify/docker/BuildMojo.java
+++ b/src/main/java/com/spotify/docker/BuildMojo.java
@@ -458,7 +458,7 @@ public class BuildMojo extends AbstractDockerMojo {
   }
 
   private void tagImage(final DockerClient docker)
-      throws DockerException, InterruptedException {
+      throws DockerException, InterruptedException, MojoExecutionException {
     final String imageNameWithoutTag = parseImageName(imageName)[0];
     for (final String imageTag : imageTags) {
       if (!isNullOrEmpty(imageTag)){

--- a/src/main/java/com/spotify/docker/Utils.java
+++ b/src/main/java/com/spotify/docker/Utils.java
@@ -30,9 +30,15 @@ import org.apache.maven.plugin.logging.Log;
 
 import java.io.IOException;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 public class Utils {
 
-  public static String[] parseImageName(String imageName) {
+  public static String[] parseImageName(String imageName) throws MojoExecutionException {
+    if (isNullOrEmpty(imageName)) {
+      throw new MojoExecutionException("You must specify an \"imageName\" in your "
+                                       + "docker-maven-client's plugin configuration");
+    }
     final int lastSlashIndex = imageName.lastIndexOf('/');
     final int lastColonIndex = imageName.lastIndexOf(':');
 

--- a/src/test/java/com/spotify/docker/UtilsTest.java
+++ b/src/test/java/com/spotify/docker/UtilsTest.java
@@ -23,6 +23,8 @@ package com.spotify.docker;
 
 import junit.framework.TestCase;
 
+import org.apache.maven.plugin.MojoExecutionException;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -32,7 +34,7 @@ import static com.spotify.docker.Utils.parseImageName;
 
 public class UtilsTest extends TestCase {
 
-  public void testParseImageName() {
+  public void testParseImageName() throws MojoExecutionException {
     assertParsedCorrectly("registry.spotify.net/spotify/image", "tag",
                           parseImageName("registry.spotify.net/spotify/image:tag"));
 


### PR DESCRIPTION
Throw MojoExecutionException with a descriptive error message
instead of NPE when imageName is not specified.