### PR TITLE
Added documentation about email configuration in settings.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ credentials in your Maven's global `settings.xml` file as part of the `<servers>
         <id>docker-hub</id>
         <username>foo</username>
         <password>secret-password</password>
+        <configuration>
+          <email>foo@example.org</email>
+      </configuration>
       </server>
     </servers>
 


### PR DESCRIPTION
Make documentation explicit about the fact that email configuration is needed for push to work in Docker  Hub.,

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/spotify/docker-maven-plugin/101)
<!-- Reviewable:end -->
