### PR TITLE
fix NPE if tagInfoFile does not contain parent dir

### DIFF
--- a/src/main/java/com/spotify/docker/BuildMojo.java
+++ b/src/main/java/com/spotify/docker/BuildMojo.java
@@ -274,7 +274,9 @@ public class BuildMojo extends AbstractDockerMojo {
 
     // Write image info file
     final Path imageInfoPath = Paths.get(tagInfoFile);
-    Files.createDirectories(imageInfoPath.getParent());
+    if (imageInfoPath.getParent() != null) {
+      Files.createDirectories(imageInfoPath.getParent());
+    }
     Files.write(imageInfoPath, buildInfo.toJsonBytes());
 
     if ("docker".equals(mavenProject.getPackaging())) {

--- a/src/test/resources/pom-build-with-tagInfoFile.xml
+++ b/src/test/resources/pom-build-with-tagInfoFile.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>Docker Maven Plugin Test Pom</name>
+    <groupId>com.spotify</groupId>
+    <artifactId>docker-maven-plugin-test</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.1-SNAPSHOT</version>
+                <configuration>
+                    <tagInfoFile>image_info.json</tagInfoFile>
+                    <!-- we have to supply values for all params because unit testing framework -->
+                    <!-- doesn't set default values even though the are set in mojo-->
+                    <dockerHost>http://host:2375</dockerHost>
+                    <dockerDirectory>src/test/resources/dockerDirectory</dockerDirectory>
+                    <imageName>busybox</imageName>
+                    <!-- test image is pushed -->
+                    <pushImage>true</pushImage>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
In the random case that someone tries to set tagInfoFile to a path that
is in the root of the project, currently docker-maven-plugin throws a
NullPointerException because `path.getParent()` returns null.