### PR TITLE
Fix nullpointer while reading settings.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ credentials in your Maven's global `settings.xml` file as part of the `<servers>
         <id>docker-hub</id>
         <username>foo</username>
         <password>secret-password</password>
+        <configuration>
+          <email>foo@foo.bar</email>
+        </configuration>
       </server>
     </servers>
 

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,12 @@
       <artifactId>maven-plugin-testing-harness</artifactId>
       <version>3.1.0</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -164,7 +170,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.9.5</version>
+      <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -173,7 +179,24 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>2.0.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <version>4.1.6.RELEASE</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>

--- a/src/main/java/com/spotify/docker/AbstractDockerMojo.java
+++ b/src/main/java/com/spotify/docker/AbstractDockerMojo.java
@@ -21,10 +21,13 @@
 
 package com.spotify.docker;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.spotify.docker.client.DefaultDockerClient.NO_TIMEOUT;
+
 import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerCertificateException;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.messages.AuthConfig;
-
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecution;
@@ -34,9 +37,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.settings.Server;
 import org.apache.maven.settings.Settings;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
-
-import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.spotify.docker.client.DefaultDockerClient.NO_TIMEOUT;
 
 abstract class AbstractDockerMojo extends AbstractMojo {
 
@@ -68,8 +68,7 @@ abstract class AbstractDockerMojo extends AbstractMojo {
   public void execute() throws MojoExecutionException {
     DockerClient client = null;
     try {
-       final DefaultDockerClient.Builder builder = DefaultDockerClient.fromEnv()
-           .readTimeoutMillis(NO_TIMEOUT);
+      final DefaultDockerClient.Builder builder = getBuilder();
 
       final String dockerHost = rawDockerHost();
       if (!isNullOrEmpty(dockerHost)) {
@@ -122,6 +121,11 @@ abstract class AbstractDockerMojo extends AbstractMojo {
     }
   }
 
+  protected DefaultDockerClient.Builder getBuilder() throws DockerCertificateException {
+    return DefaultDockerClient.fromEnv()
+      .readTimeoutMillis(NO_TIMEOUT);
+  }
+
   protected abstract void execute(final DockerClient dockerClient) throws Exception;
 
   protected String rawDockerHost() {
@@ -152,8 +156,10 @@ abstract class AbstractDockerMojo extends AbstractMojo {
     String email = null;
 
     final Xpp3Dom configuration = (Xpp3Dom) server.getConfiguration();
+
     if (configuration != null) {
       final Xpp3Dom emailNode = configuration.getChild("email");
+
       if (emailNode != null) {
         email = emailNode.getValue();
       }

--- a/src/test/java/com/spotify/docker/AbstractDockerMojoTest.java
+++ b/src/test/java/com/spotify/docker/AbstractDockerMojoTest.java
@@ -1,0 +1,220 @@
+package com.spotify.docker;
+
+import com.spotify.docker.client.DefaultDockerClient;
+import com.spotify.docker.client.DockerCertificateException;
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.messages.AuthConfig;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.settings.Server;
+import org.apache.maven.settings.Settings;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.*;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by Simon Weis on 5/5/15.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class AbstractDockerMojoTest {
+
+  private static final String DOCKER_HOST = "testhost";
+  private static final String SERVER_ID = "testId";
+  private static final String REGISTRY_URL = "https://my.docker.reg";
+  private static final String USERNAME = "username";
+  private static final String PASSWORD = "password";
+  private static final String CONFIGURATION_PROPERTY = "configuration";
+  private static final String EMAIL_PROPERTY = "email";
+  private static final String EMAIL = "user@host.domain";
+  private static final String AUTHORIZATION_EXCEPTION = "Incomplete Docker registry authorization credentials.";
+  private static final String DEFAULT_REGISTRY = "https://index.docker.io/v1/";
+
+  @Mock
+  private MavenSession session;
+
+  @Mock
+  private MojoExecution execution;
+
+  @Mock
+  private Settings settings;
+
+  @Mock
+  private DefaultDockerClient.Builder builder;
+
+  @Captor
+  private ArgumentCaptor<AuthConfig> authConfigCaptor;
+
+  @InjectMocks
+  private AbstractDockerMojo sut = new AbstractDockerMojo() {
+    @Override
+    protected void execute(DockerClient dockerClient) throws Exception {
+
+    }
+
+    @Override
+    protected DefaultDockerClient.Builder getBuilder() throws DockerCertificateException {
+      return builder;
+    }
+  };
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void testDockerHostSet() throws Exception {
+    ReflectionTestUtils.setField(sut, "dockerHost", DOCKER_HOST);
+
+    sut.execute();
+
+    verify(builder).uri(DOCKER_HOST);
+  }
+
+  @Test
+  public void testSettingsNoUsername() throws Exception {
+    ReflectionTestUtils.setField(sut, "serverId", SERVER_ID);
+
+    Server server = mockServer();
+
+    server.setUsername(null);
+
+    when(settings.getServer(SERVER_ID)).thenReturn(server);
+
+    Throwable cause = null;
+
+    try {
+      sut.execute();
+    } catch (MojoExecutionException exception) {
+      cause = exception.getCause();
+    }
+
+    assertThat(cause).isNotNull().isExactlyInstanceOf(MojoExecutionException.class).
+      hasMessageStartingWith(AUTHORIZATION_EXCEPTION);
+  }
+
+  @Test
+  public void testSettingsNoPassword() throws Exception {
+    ReflectionTestUtils.setField(sut, "serverId", SERVER_ID);
+
+    Server server = mockServer();
+
+    server.setPassword(null);
+
+    when(settings.getServer(SERVER_ID)).thenReturn(server);
+
+    Throwable cause = null;
+
+    try {
+      sut.execute();
+    } catch (MojoExecutionException exception) {
+      cause = exception.getCause();
+    }
+
+    assertThat(cause).isNotNull().isExactlyInstanceOf(MojoExecutionException.class).
+      hasMessageStartingWith(AUTHORIZATION_EXCEPTION);
+  }
+
+
+  @Test
+  public void testSettingsNoConfiguration() throws Exception {
+    ReflectionTestUtils.setField(sut, "serverId", SERVER_ID);
+
+    Server server = mockServer();
+
+    server.setConfiguration(null);
+
+    when(settings.getServer(SERVER_ID)).thenReturn(server);
+
+    Throwable cause = null;
+
+    try {
+      sut.execute();
+    } catch (MojoExecutionException exception) {
+      cause = exception.getCause();
+    }
+
+    assertThat(cause).isNotNull().isExactlyInstanceOf(MojoExecutionException.class).
+      hasMessageStartingWith(AUTHORIZATION_EXCEPTION);
+  }
+
+
+  @Test
+  public void testSettingsNoEmail() throws Exception {
+    ReflectionTestUtils.setField(sut, "serverId", SERVER_ID);
+
+    Server server = mockServer();
+
+    server.setConfiguration(new Xpp3Dom(CONFIGURATION_PROPERTY));
+
+    when(settings.getServer(SERVER_ID)).thenReturn(server);
+
+    Throwable cause = null;
+
+    try {
+      sut.execute();
+    } catch (MojoExecutionException exception) {
+      cause = exception.getCause();
+    }
+
+    assertThat(cause).isNotNull().isExactlyInstanceOf(MojoExecutionException.class).
+      hasMessageStartingWith(AUTHORIZATION_EXCEPTION);
+  }
+
+  @Test
+  public void testAuthorizationConfiguration() throws Exception {
+    ReflectionTestUtils.setField(sut, "serverId", SERVER_ID);
+
+    when(settings.getServer(SERVER_ID)).thenReturn(mockServer());
+    when(builder.authConfig(authConfigCaptor.capture())).thenReturn(builder);
+
+    sut.execute();
+
+    AuthConfig authConfig = authConfigCaptor.getValue();
+    assertThat(authConfig).isNotNull();
+    assertThat(authConfig.email()).isEqualTo(EMAIL);
+    assertThat(authConfig.password()).isEqualTo(PASSWORD);
+    assertThat(authConfig.username()).isEqualTo(USERNAME);
+    assertThat(authConfig.serverAddress()).isEqualTo(DEFAULT_REGISTRY);
+  }
+
+  @Test
+  public void testAuthorizationConfigurationWithServerAddress() throws Exception {
+    ReflectionTestUtils.setField(sut, "serverId", SERVER_ID);
+    ReflectionTestUtils.setField(sut, "registryUrl", REGISTRY_URL);
+
+    when(settings.getServer(SERVER_ID)).thenReturn(mockServer());
+    when(builder.authConfig(authConfigCaptor.capture())).thenReturn(builder);
+
+    sut.execute();
+
+    AuthConfig authConfig = authConfigCaptor.getValue();
+    assertThat(authConfig).isNotNull();
+    assertThat(authConfig.serverAddress()).isEqualTo(REGISTRY_URL);
+  }
+
+  private Server mockServer() {
+    Server server = new Server();
+    server.setUsername(USERNAME);
+    server.setPassword(PASSWORD);
+
+    Xpp3Dom email = new Xpp3Dom(EMAIL_PROPERTY);
+    email.setValue(EMAIL);
+
+    Xpp3Dom configuration = new Xpp3Dom(CONFIGURATION_PROPERTY);
+    configuration.addChild(email);
+
+    server.setConfiguration(configuration);
+
+    return server;
+  }
+}

--- a/src/test/java/com/spotify/docker/UtilsTest.java
+++ b/src/test/java/com/spotify/docker/UtilsTest.java
@@ -21,48 +21,72 @@
 
 package com.spotify.docker;
 
-import junit.framework.TestCase;
-
+import com.spotify.docker.client.AnsiProgressHandler;
+import com.spotify.docker.client.DockerClient;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
-import static com.spotify.docker.Utils.parseImageName;
+public class UtilsTest {
 
-public class UtilsTest extends TestCase {
+  private static final String TAG = "tag";
+  private static final String IMAGE = "image";
+  private static final String IMAGE_WITH_SEPERATOR = "image:";
+  private static final String IMAGE_WITH_LIBRARY = "library/image";
+  private static final String IMAGE_FROM_REGISTRY = "registry:80/library/image";
+  private static final String IMAGE_WITH_TAG = "image:tag";
+  private static final String IMAGE_FROM_LIB_WITH_TAG = "library/image:tag";
+  private static final String IMAGE_FROM_REG_WITH_TAG = "registry:80/library/image:tag";
 
+
+  @Test
   public void testParseImageName() throws MojoExecutionException {
-    assertParsedCorrectly("registry.spotify.net/spotify/image", "tag",
-                          parseImageName("registry.spotify.net/spotify/image:tag"));
-
-    assertParsedCorrectly("registry:80/spotify/image", "tag",
-                          parseImageName("registry:80/spotify/image:tag"));
-
-    assertParsedCorrectly("spotify/image", "tag", parseImageName("spotify/image:tag"));
-
-    assertParsedCorrectly("image", "tag", parseImageName("image:tag"));
-
-    assertParsedCorrectly("image", null, parseImageName("image:"));
-
-    assertParsedCorrectly("image", null, parseImageName("image"));
+    String[] result = Utils.parseImageName(IMAGE);
+    assertThat(result).containsExactly(IMAGE, null);
   }
 
-  private void assertParsedCorrectly(String expectedRepo,
-                                     String expectedTag,
-                                     String[] actualRepoTag) {
-    assertEquals("wrong repo", expectedRepo, actualRepoTag[0]);
-    assertEquals("wrong tag", expectedTag, actualRepoTag[1]);
+  @Test
+  public void testParseImageNameWithSeperator() throws MojoExecutionException {
+    String[] result = Utils.parseImageName(IMAGE_WITH_SEPERATOR);
+    assertThat(result).containsExactly(IMAGE, null);
   }
 
-  public synchronized static ByteArrayInputStream getMockInputStream(String filename) {
-    try {
-      return new ByteArrayInputStream(Files.readAllBytes(Paths.get(filename)));
-    } catch (IOException e) {
-      throw new RuntimeException("Exception reading json stream from file", e);
-    }
+  @Test
+  public void testParseImageNameWithTag() throws MojoExecutionException {
+    String[] result = Utils.parseImageName(IMAGE_WITH_TAG);
+    assertThat(result).containsExactly(IMAGE, TAG);
   }
 
+  @Test
+  public void testParseImageNameWithLibrary() throws MojoExecutionException {
+    String[] result = Utils.parseImageName(IMAGE_WITH_LIBRARY);
+    assertThat(result).containsExactly(IMAGE_WITH_LIBRARY, null);
+  }
+
+  @Test
+  public void testParseImageNameWithLibraryAndTag() throws MojoExecutionException {
+    String[] result = Utils.parseImageName(IMAGE_FROM_LIB_WITH_TAG);
+    assertThat(result).containsExactly(IMAGE_WITH_LIBRARY, TAG);
+  }
+
+  @Test
+  public void testParseImageNameFromRegistryAndTag() throws MojoExecutionException {
+    String[] result = Utils.parseImageName(IMAGE_FROM_REG_WITH_TAG);
+    assertThat(result).containsExactly(IMAGE_FROM_REGISTRY, TAG);
+  }
+
+  @Test
+  public void testPushImage() throws Exception {
+    DockerClient dockerClient = mock(DockerClient.class);
+    Log log = mock(Log.class);
+    Utils.pushImage(dockerClient, IMAGE, log);
+
+    verify(dockerClient).push(eq(IMAGE), any(AnsiProgressHandler.class));
+  }
 }


### PR DESCRIPTION
When there is no configuration section in settings.xml a nullpointer occurs.
This commit prevents the NPE and raises test coverage.