### PR TITLE
Updated README.md to include missing configuration section for authen…

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ credentials in your Maven's global `settings.xml` file as part of the `<servers>
         <id>docker-hub</id>
         <username>foo</username>
         <password>secret-password</password>
+        <configuration>
+          <email>foo@email.com</email>
+        </configuration>
       </server>
     </servers>
 


### PR DESCRIPTION
Updated README.md to include missing configuration section for authenticating with private repositories in settings.xml.

If you attempt to run mvn docker:push to a private repo without this section you get the following error:

[ERROR] Failed to execute goal com.spotify:docker-maven-plugin:0.2.11:push (default-cli) on project coreos-sandbox: Exception caught: Incomplete Docker registry authorization credentials. Please provide all of username, password, and email or none.