### PR TITLE
Use more specific config key for docker profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.spotify</groupId>
   <artifactId>docker-maven-plugin</artifactId>
-  <version>0.2.14-SNAPSHOT</version>
+  <version>0.3.0-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
   <name>docker-maven-plugin</name>
   <description>A maven plugin for docker</description>

--- a/src/main/java/com/spotify/docker/BuildMojo.java
+++ b/src/main/java/com/spotify/docker/BuildMojo.java
@@ -317,7 +317,7 @@ public class BuildMojo extends AbstractDockerMojo {
 
     final Config config = ConfigFactory.load();
 
-    defaultProfile = get(defaultProfile, config, "docker.build.defaultProfile");
+    defaultProfile = get(defaultProfile, config, "dockerMavenPlugin.build.defaultProfile");
 
     if (profile == null) {
       if (defaultProfile == null) {
@@ -333,7 +333,7 @@ public class BuildMojo extends AbstractDockerMojo {
 
     Config profiles;
     try {
-      profiles = config.getConfig("docker.build.profiles");
+      profiles = config.getConfig("dockerMavenPlugin.build.profiles");
     } catch (ConfigException.Missing e) {
       profiles = ConfigFactory.empty();
     }


### PR DESCRIPTION
to prevent collisions with user specified properties.

Fixes #24