### PR TITLE
Add pushImageTag functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,25 +104,12 @@ In order for this to succeed, at least one imageTag must be present in the confi
       <plugins>
         ...
         <plugin>
-          <groupId>com.spotify</groupId>
-          <artifactId>docker-maven-plugin</artifactId>
-          <version>VERSION GOES HERE</version>
           <configuration>
-            <imageName>example</imageName>
-            <baseImage>java</baseImage>
+            ...
             <imageTags>
                <imageTag>${project.version}</imageTag>
                <imageTag>latest</imageTag>
             </imageTags>
-            <entryPoint>["java", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
-            <!-- copy the service's jar file from target into the root directory of the image -->
-            <resources>
-               <resource>
-                 <targetPath>/</targetPath>
-                 <directory>${project.build.directory}</directory>
-                 <include>${project.build.finalName}.jar</include>
-               </resource>
-            </resources>
           </configuration>
         </plugin>
         ...

--- a/README.md
+++ b/README.md
@@ -94,6 +94,41 @@ To push the image you just built to the registry, specify the `pushImage` flag.
 
     mvn clean package docker:build -DpushImage
 
+To push only specific tags of the image to the registry, specify the `pushImageTag` flag.
+
+    mvn clean package docker:build -DpushImageTag
+
+In order for this to succeed, at least one imageTag must be present in the config, multiple tags can be used.
+
+    <build>
+      <plugins>
+        ...
+        <plugin>
+          <groupId>com.spotify</groupId>
+          <artifactId>docker-maven-plugin</artifactId>
+          <version>VERSION GOES HERE</version>
+          <configuration>
+            <imageName>example</imageName>
+            <baseImage>java</baseImage>
+            <imageTags>
+               <imageTag>${project.version}</imageTag>
+               <imageTag>latest</imageTag>
+            </imageTags>
+            <entryPoint>["java", "-jar", "/${project.build.finalName}.jar"]</entryPoint>
+            <!-- copy the service's jar file from target into the root directory of the image -->
+            <resources>
+               <resource>
+                 <targetPath>/</targetPath>
+                 <directory>${project.build.directory}</directory>
+                 <include>${project.build.finalName}.jar</include>
+               </resource>
+            </resources>
+          </configuration>
+        </plugin>
+        ...
+      </plugins>
+    </build>
+
 By default the plugin will try to connect to docker on localhost:2375. Set the DOCKER_HOST 
 environment variable to connect elsewhere. 
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ In order for this to succeed, at least one imageTag must be present in the confi
       </plugins>
     </build>
 
+Tags-to-be-pushed can also be specified directly on the command line with
+
+    mvn ... docker:build -DpushImageTags -DdockerImageTag=latest -DdockerImageTag=another-tag
+
 By default the plugin will try to connect to docker on localhost:2375. Set the DOCKER_HOST 
 environment variable to connect elsewhere. 
 

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,14 @@
           <findbugsXmlOutputDirectory>${project.build.directory}/findbugs
           </findbugsXmlOutputDirectory>
           <excludeFilterFile>${project.basedir}/findbugs-exclude.xml</excludeFilterFile>
-        </configuration>
+  </configuration>
+        <dependencies>
+	  <dependency>
+	    <groupId>org.apache.ant</groupId>
+            <artifactId>ant</artifactId>
+            <version>1.9.4</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <phase>verify</phase>

--- a/src/main/java/com/spotify/docker/BuildMojo.java
+++ b/src/main/java/com/spotify/docker/BuildMojo.java
@@ -69,6 +69,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Ordering.natural;
 import static com.spotify.docker.Utils.parseImageName;
 import static com.spotify.docker.Utils.pushImage;
+import static com.spotify.docker.Utils.pushImageTag;
 import static com.typesafe.config.ConfigRenderOptions.concise;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyList;
@@ -113,6 +114,10 @@ public class BuildMojo extends AbstractDockerMojo {
   /** Flag to push image after it is built. Defaults to false. */
   @Parameter(property = "pushImage", defaultValue = "false")
   private boolean pushImage;
+
+  /** Flag to push image using their tags after it is built. Defaults to false. */
+  @Parameter(property = "pushImageTag", defaultValue = "false")
+  private boolean pushImageTag;
 
   /** Flag to use force option while tagging. Defaults to false. */
   @Parameter(property = "forceTags", defaultValue = "false")
@@ -227,6 +232,10 @@ public class BuildMojo extends AbstractDockerMojo {
     return pushImage;
   }
 
+  public boolean getPushImageTag() {
+    return pushImageTag;
+  }
+
   public boolean getForceTags() {
     return forceTags;
   }
@@ -319,6 +328,11 @@ public class BuildMojo extends AbstractDockerMojo {
     if ("docker".equals(mavenProject.getPackaging())) {
       final File imageArtifact = createImageArtifact(mavenProject.getArtifact(), buildInfo);
       mavenProject.getArtifact().setFile(imageArtifact);
+    }
+
+    // Push specific tags specified in pom rather than all images
+    if (pushImageTag) {
+      pushImageTag(docker, imageName, imageTags, getLog());
     }
 
     if (pushImage) {

--- a/src/main/java/com/spotify/docker/Utils.java
+++ b/src/main/java/com/spotify/docker/Utils.java
@@ -29,6 +29,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 
 import java.io.IOException;
+import java.util.List;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
@@ -65,4 +66,20 @@ public class Utils {
       docker.push(imageName, new AnsiProgressHandler());
   }
 
+  // push just the tags listed in the pom rather than all images using imageName
+  public static void pushImageTag(DockerClient docker, String imageName,
+                                List<String> imageTags, Log log)
+      throws MojoExecutionException, DockerException, IOException, InterruptedException {
+      // tags should not be empty if you have specified the option to push tags
+      if (imageTags.isEmpty()) {
+        throw new MojoExecutionException("You have used option \"pushImageTag\" but have"
+                                         + " not specified an \"imageTag\" in your"
+                                         + " docker-maven-client's plugin configuration");
+      }
+      for (final String imageTag : imageTags) {
+       final String imageNameWithTag = imageName + ":" + imageTag;
+       log.info("Pushing " + imageName + ":" + imageTag);
+       docker.push(imageNameWithTag, new AnsiProgressHandler());
+      }
+  }
 }

--- a/src/test/resources/pom-build-missing-push-tags.xml
+++ b/src/test/resources/pom-build-missing-push-tags.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>Docker Maven Plugin Test Pom</name>
+    <groupId>com.spotify</groupId>
+    <artifactId>docker-maven-plugin-test</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.1-SNAPSHOT</version>
+                <configuration>
+                    <!-- we have to supply values for all params because unit testing framework -->
+                    <!-- doesn't set default values even though the are set in mojo-->
+                    <dockerHost>http://host:2375</dockerHost>
+                    <dockerDirectory>src/test/resources/dockerDirectory</dockerDirectory>
+		    <imageName>busybox</imageName>
+                    <!-- test image tag is pushed -->
+                    <pushImageTag>true</pushImageTag>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/pom-build-push-tag.xml
+++ b/src/test/resources/pom-build-push-tag.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>Docker Maven Plugin Test Pom</name>
+    <groupId>com.spotify</groupId>
+    <artifactId>docker-maven-plugin-test</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.1-SNAPSHOT</version>
+                <configuration>
+                    <!-- we have to supply values for all params because unit testing framework -->
+                    <!-- doesn't set default values even though the are set in mojo-->
+                    <dockerHost>http://host:2375</dockerHost>
+                    <dockerDirectory>src/test/resources/dockerDirectory</dockerDirectory>
+		    <imageName>busybox</imageName>
+		    <imageTags>
+			    <imageTag>latest</imageTag>
+                    </imageTags>
+                    <!-- test image tag is pushed -->
+                    <pushImageTag>true</pushImageTag>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/pom-build-push-tags.xml
+++ b/src/test/resources/pom-build-push-tags.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>Docker Maven Plugin Test Pom</name>
+    <groupId>com.spotify</groupId>
+    <artifactId>docker-maven-plugin-test</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.1-SNAPSHOT</version>
+                <configuration>
+                    <!-- we have to supply values for all params because unit testing framework -->
+                    <!-- doesn't set default values even though the are set in mojo-->
+                    <dockerHost>http://host:2375</dockerHost>
+                    <dockerDirectory>src/test/resources/dockerDirectory</dockerDirectory>
+		    <imageName>busybox</imageName>
+		    <imageTags>
+			    <imageTag>late</imageTag>
+			    <imageTag>later</imageTag>
+			    <imageTag>latest</imageTag>
+                    </imageTags>
+                    <!-- test image tag is pushed -->
+                    <pushImageTag>true</pushImageTag>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
for software houses that create a lot of images, the maven plugin will try to push all tags when you specify pushImage. I have added a more focused pushImageTag so that only images, specified in the pom, are uploaded to the registry.
This should resolve issue #40 