### PR TITLE
Write digest to image info file on push

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
-      <version>3.1.4</version>
+      <version>3.1.5</version>
       <classifier>shaded</classifier>
     </dependency>
     <dependency>

--- a/src/main/java/com/spotify/docker/BuildMojo.java
+++ b/src/main/java/com/spotify/docker/BuildMojo.java
@@ -69,6 +69,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Ordering.natural;
 import static com.spotify.docker.Utils.parseImageName;
 import static com.spotify.docker.Utils.pushImage;
+import static com.spotify.docker.Utils.writeImageInfoFile;
 import static com.typesafe.config.ConfigRenderOptions.concise;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyList;
@@ -309,21 +310,17 @@ public class BuildMojo extends AbstractDockerMojo {
 
     final DockerBuildInformation buildInfo = new DockerBuildInformation(imageName, getLog());
 
-    // Write image info file
-    final Path imageInfoPath = Paths.get(tagInfoFile);
-    if (imageInfoPath.getParent() != null) {
-      Files.createDirectories(imageInfoPath.getParent());
-    }
-    Files.write(imageInfoPath, buildInfo.toJsonBytes());
-
     if ("docker".equals(mavenProject.getPackaging())) {
       final File imageArtifact = createImageArtifact(mavenProject.getArtifact(), buildInfo);
       mavenProject.getArtifact().setFile(imageArtifact);
     }
 
     if (pushImage) {
-      pushImage(docker, imageName, getLog());
+      pushImage(docker, imageName, getLog(), buildInfo);
     }
+
+    // Write image info file
+    writeImageInfoFile(buildInfo, tagInfoFile);
   }
 
   private File createImageArtifact(final Artifact mainArtifact,

--- a/src/main/java/com/spotify/docker/DockerBuildInformation.java
+++ b/src/main/java/com/spotify/docker/DockerBuildInformation.java
@@ -54,12 +54,18 @@ public class DockerBuildInformation {
   @JsonProperty("commit")
   private String commit;
 
+  @JsonProperty("digest")
+  private String digest;
 
   public DockerBuildInformation(final String image, final Log log) {
     this.image = image;
     updateGitInformation(log);
   }
 
+  public DockerBuildInformation setDigest(final String digest) {
+    this.digest = digest;
+    return this;
+  }
 
   private void updateGitInformation(Log log) {
     try {
@@ -95,5 +101,9 @@ public class DockerBuildInformation {
 
   public String getCommit(){
     return commit;
+  }
+
+  public String getDigest() {
+    return digest;
   }
 }

--- a/src/main/java/com/spotify/docker/PushMojo.java
+++ b/src/main/java/com/spotify/docker/PushMojo.java
@@ -44,7 +44,7 @@ public class PushMojo extends AbstractDockerMojo {
 
   protected void execute(DockerClient docker)
       throws MojoExecutionException, DockerException, IOException, InterruptedException {
-    pushImage(docker, imageName, getLog());
+    pushImage(docker, imageName, getLog(), null);
   }
 
 }

--- a/src/main/java/com/spotify/docker/TagMojo.java
+++ b/src/main/java/com/spotify/docker/TagMojo.java
@@ -30,12 +30,12 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.eclipse.jgit.api.errors.GitAPIException;
 
-import java.io.FileOutputStream;
 import java.io.IOException;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.spotify.docker.Utils.parseImageName;
 import static com.spotify.docker.Utils.pushImage;
+import static com.spotify.docker.Utils.writeImageInfoFile;
 
 /**
  * Applies a tag to a docker image. Optionally, <tt>useGitCommitId</tt> can be used to generate a
@@ -113,16 +113,13 @@ public class TagMojo extends AbstractDockerMojo {
     getLog().info(String.format("Creating tag %s from %s", normalizedName, image));
     docker.tag(image, normalizedName, forceTags);
 
-    final FileOutputStream jsonOutput = new FileOutputStream(tagInfoFile);
-    try {
-      jsonOutput.write(new DockerBuildInformation(normalizedName, getLog()).toJsonBytes());
-    } finally {
-      jsonOutput.close();
-    }
+    final DockerBuildInformation buildInfo = new DockerBuildInformation(normalizedName, getLog());
 
     if (pushImage) {
-      pushImage(docker, newName, getLog());
+      pushImage(docker, newName, getLog(), buildInfo);
     }
+
+    writeImageInfoFile(buildInfo, tagInfoFile);
   }
 
 }

--- a/src/main/java/com/spotify/docker/Utils.java
+++ b/src/main/java/com/spotify/docker/Utils.java
@@ -76,7 +76,8 @@ public class Utils {
     docker.push(imageName, handler);
 
     if (buildInfo != null) {
-      buildInfo.setDigest(handler.digest());
+      final String imageNameWithoutTag = parseImageName(imageName)[0];
+      buildInfo.setDigest(imageNameWithoutTag + "@" + handler.digest());
     }
   }
 

--- a/src/test/java/com/spotify/docker/BuildMojoTest.java
+++ b/src/test/java/com/spotify/docker/BuildMojoTest.java
@@ -161,7 +161,43 @@ public class BuildMojoTest extends AbstractMojoTestCase {
     final ObjectMapper objectMapper = new ObjectMapper();
     final JsonNode node = objectMapper.readTree(new File(mojo.tagInfoFile));
 
-    assertEquals(digest, node.get("digest").asText());
+    assertEquals("busybox@" + digest, node.get("digest").asText());
+  }
+
+  public void testDigestWrittenOnBuildWithPushAndExplicitTag() throws Exception {
+    final File pom = getTestFile("src/test/resources/pom-build-push-with-tag.xml");
+    assertNotNull("Null pom.xml", pom);
+    assertTrue("pom.xml does not exist", pom.exists());
+
+    final BuildMojo mojo = setupMojo(pom);
+    final DockerClient docker = mock(DockerClient.class);
+
+    final String digest =
+        "sha256:ebd39c3e3962f804787f6b0520f8f1e35fbd5a01ab778ac14c8d6c37978e8445";
+    final ProgressMessage digestProgressMessage = new ProgressMessage().status(
+        "Digest: " + digest);
+
+    doAnswer(new Answer() {
+      @Override
+      public Object answer(final InvocationOnMock invocationOnMock) throws Throwable {
+        final ProgressHandler handler = (ProgressHandler) invocationOnMock.getArguments()[1];
+        handler.progress(digestProgressMessage);
+        return null;
+      }
+    }).when(docker).push(anyString(), any(ProgressHandler.class));
+
+    mojo.execute(docker);
+
+    verify(docker).build(eq(Paths.get("target/docker")), eq("busybox:sometag"),
+                         any(AnsiProgressHandler.class));
+    verify(docker).push(eq("busybox:sometag"), any(AnsiProgressHandler.class));
+
+    assertFileExists(mojo.tagInfoFile);
+
+    final ObjectMapper objectMapper = new ObjectMapper();
+    final JsonNode node = objectMapper.readTree(new File(mojo.tagInfoFile));
+
+    assertEquals("busybox@" + digest, node.get("digest").asText());
   }
 
   public void testBuildWithPull() throws Exception {

--- a/src/test/java/com/spotify/docker/UtilsTest.java
+++ b/src/test/java/com/spotify/docker/UtilsTest.java
@@ -85,7 +85,8 @@ public class UtilsTest {
   public void testPushImage() throws Exception {
     DockerClient dockerClient = mock(DockerClient.class);
     Log log = mock(Log.class);
-    Utils.pushImage(dockerClient, IMAGE, log);
+    final DockerBuildInformation buildInfo = mock(DockerBuildInformation.class);
+    Utils.pushImage(dockerClient, IMAGE, log, buildInfo);
 
     verify(dockerClient).push(eq(IMAGE), any(AnsiProgressHandler.class));
   }

--- a/src/test/resources/pom-build-push-with-tag.xml
+++ b/src/test/resources/pom-build-push-with-tag.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>Docker Maven Plugin Test Pom</name>
+    <groupId>com.spotify</groupId>
+    <artifactId>docker-maven-plugin-test</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.1-SNAPSHOT</version>
+                <configuration>
+                    <!-- we have to supply values for all params because unit testing framework -->
+                    <!-- doesn't set default values even though the are set in mojo-->
+                    <dockerHost>http://host:2375</dockerHost>
+                    <dockerDirectory>src/test/resources/dockerDirectory</dockerDirectory>
+                    <imageName>busybox:sometag</imageName>
+                    <!-- test image is pushed -->
+                    <pushImage>true</pushImage>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
This adds a new filed to the image info file named "digest", which
contains the digest of the image if it was returned by the registry
to which it was pushed. The digest field does NOT include the image
name. I.e. it's "sha256:12ae23" rather than "name@sha256:12ae23".