### PR TITLE
update docker-client to 3.1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
-      <version>3.1.5</version>
+      <version>3.1.8</version>
       <classifier>shaded</classifier>
     </dependency>
     <dependency>


### PR DESCRIPTION
pulls in [a fix][1] for the image digest format changing in Docker v1.8

[1]: https://github.com/spotify/docker-client/issues/250