### PR TITLE
when ADDing files, write dest as a directory

### DIFF
--- a/src/test/java/com/spotify/docker/BuildMojoTest.java
+++ b/src/test/java/com/spotify/docker/BuildMojoTest.java
@@ -61,7 +61,6 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class BuildMojoTest extends AbstractMojoTestCase {
 
@@ -70,9 +69,9 @@ public class BuildMojoTest extends AbstractMojoTestCase {
       "MAINTAINER user",
       "ENV FOO BAR",
       "WORKDIR /opt/app",
-      "ADD resources/parent/child/child.xml resources/parent/child/child.xml",
-      "ADD resources/parent/parent.xml resources/parent/parent.xml",
-      "ADD copy2.json copy2.json",
+      "ADD resources/parent/child/child.xml resources/parent/child/",
+      "ADD resources/parent/parent.xml resources/parent/",
+      "ADD copy2.json .",
       "RUN ln -s /a /b",
       "RUN wget 127.0.0.1:8080",
       "EXPOSE 8080 8081",
@@ -88,7 +87,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
       "ENV FOO BAR",
       "ENV FOOZ BARZ",
       "ENV PROPERTY_HELLO HELLO_VALUE",
-      "ADD /xml/pom-build-with-profile.xml /xml/pom-build-with-profile.xml",
+      "ADD /xml/pom-build-with-profile.xml /xml/",
       "EXPOSE 8080 8081 8082",
       "ENTRYPOINT date",
       "CMD [\"-u\"]"


### PR DESCRIPTION
Fixes #123 where a tar file being ADD-ed as

```
ADD /opt/apps/spar-api.tar.gz /opt/apps/spar-api.tar.gz
```

results in Docker expanding the tar's contents under `/opt/apps/spar-api.tar.gz/<contents>`.

Instead this change should generate an ADD instruction like

```
ADD /opt/apps/spar-api.tar.gz /opt/apps/
```

This change also accounts for simple paths like "file.txt" or "file.tar.gz" so that the ADD looks like

```
ADD file.txt .
```