### PR TITLE
use authentication from .docker/config.json

### DIFF
--- a/src/main/java/com/spotify/docker/AbstractDockerMojo.java
+++ b/src/main/java/com/spotify/docker/AbstractDockerMojo.java
@@ -216,6 +216,8 @@ abstract class AbstractDockerMojo extends AbstractMojo {
    * @return AuthConfig
    */
   protected AuthConfig authConfig() throws MojoExecutionException, SecDispatcherException {
+    // first try to construct the authentication config from the user's settings based on the
+    // <server> configured in this mojo
     if (settings != null) {
       final Server server = settings.getServer(serverId);
       if (server != null) {
@@ -268,6 +270,14 @@ abstract class AbstractDockerMojo extends AbstractMojo {
 
         return authConfigBuilder.build();
       }
+    }
+
+    // fall back to using the .docker configuration file
+    try {
+      return AuthConfig.fromDockerConfig().build();
+    } catch (IOException e) {
+      getLog()
+          .warn("IOException while reading authentication configuration from .docker directory", e);
     }
     return null;
   }

--- a/src/main/java/com/spotify/docker/AbstractDockerMojo.java
+++ b/src/main/java/com/spotify/docker/AbstractDockerMojo.java
@@ -278,6 +278,8 @@ abstract class AbstractDockerMojo extends AbstractMojo {
     } catch (IOException e) {
       getLog()
           .warn("IOException while reading authentication configuration from .docker directory", e);
+    } catch (Exception e) {
+      getLog().debug("Ignoring Exception from AuthConfig.fromDockerConfig()", e);
     }
     return null;
   }

--- a/src/main/java/com/spotify/docker/AbstractDockerMojo.java
+++ b/src/main/java/com/spotify/docker/AbstractDockerMojo.java
@@ -27,6 +27,7 @@ import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.exceptions.DockerCertificateException;
 import com.spotify.docker.client.messages.AuthConfig;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 
 import org.apache.maven.execution.MavenSession;
@@ -103,38 +104,41 @@ abstract class AbstractDockerMojo extends AbstractMojo {
 
   public int getRetryPushCount() {
     return retryPushCount;
-  };
+  }
 
+  @Override
   public void execute() throws MojoExecutionException {
-    DockerClient client = null;
-    try {
-      final DefaultDockerClient.Builder builder = getBuilder();
-
-      final String dockerHost = rawDockerHost();
-      if (!isNullOrEmpty(dockerHost)) {
-        builder.uri(dockerHost);
-      }
-      final Optional<DockerCertificates> certs = dockerCertificates();
-      if (certs.isPresent()) {
-        builder.dockerCertificates(certs.get());
-      }
-
-      final AuthConfig authConfig = authConfig();
-      if (authConfig != null) {
-        builder.authConfig(authConfig);
-      }
-
-      client = builder.build();
+    try (DockerClient client = getDockerClient()) {
       execute(client);
     } catch (Exception e) {
       throw new MojoExecutionException("Exception caught", e);
-    } finally {
-      if (client != null) {
-        client.close();
-      }
     }
   }
 
+  private DockerClient getDockerClient()
+      throws DockerCertificateException, MojoExecutionException, SecDispatcherException {
+
+    final DefaultDockerClient.Builder builder = getBuilder();
+
+    final String dockerHost = rawDockerHost();
+    if (!isNullOrEmpty(dockerHost)) {
+      builder.uri(dockerHost);
+    }
+
+    final Optional<DockerCertificates> certs = dockerCertificates();
+    if (certs.isPresent()) {
+      builder.dockerCertificates(certs.get());
+    }
+
+    final AuthConfig authConfig = authConfig();
+    if (authConfig != null) {
+      builder.authConfig(authConfig);
+    }
+
+    return builder.build();
+  }
+
+  @VisibleForTesting
   protected DefaultDockerClient.Builder getBuilder() throws DockerCertificateException {
     return DefaultDockerClient.fromEnv()
       .readTimeoutMillis(0);
@@ -149,7 +153,7 @@ abstract class AbstractDockerMojo extends AbstractMojo {
   protected Optional<DockerCertificates> dockerCertificates() throws DockerCertificateException {
     if (!isNullOrEmpty(dockerCertPath)) {
       return DockerCertificates.builder()
-        .dockerCertPath(Paths.get(dockerCertPath)).build();
+          .dockerCertPath(Paths.get(dockerCertPath)).build();
     } else {
       return Optional.absent();
     }
@@ -193,6 +197,7 @@ abstract class AbstractDockerMojo extends AbstractMojo {
 
   /**
    * Checks for incomplete private Docker registry authorization settings.
+   *
    * @param username Auth username.
    * @param password Auth password.
    * @param email    Auth email.
@@ -207,9 +212,8 @@ abstract class AbstractDockerMojo extends AbstractMojo {
 
   /**
    * Builds the AuthConfig object from server details.
+   *
    * @return AuthConfig
-   * @throws MojoExecutionException
-   * @throws SecDispatcherException
    */
   protected AuthConfig authConfig() throws MojoExecutionException, SecDispatcherException {
     if (settings != null) {
@@ -226,8 +230,8 @@ abstract class AbstractDockerMojo extends AbstractMojo {
 
         if (incompleteAuthSettings(username, password, email)) {
           throw new MojoExecutionException(
-                  "Incomplete Docker registry authorization credentials. "
-                          + "Please provide all of username, password, and email or none.");
+              "Incomplete Docker registry authorization credentials. "
+              + "Please provide all of username, password, and email or none.");
         }
 
         if (!isNullOrEmpty(username)) {
@@ -246,23 +250,23 @@ abstract class AbstractDockerMojo extends AbstractMojo {
         }
 
         return authConfigBuilder.build();
-      } else if (useConfigFile != null && useConfigFile){
+      } else if (useConfigFile != null && useConfigFile) {
 
-          final AuthConfig.Builder authConfigBuilder;
-          try {
-            if (!isNullOrEmpty(registryUrl)) {
-              authConfigBuilder = AuthConfig.fromDockerConfig(registryUrl);
-            } else {
-              authConfigBuilder = AuthConfig.fromDockerConfig();
-            }
-          } catch (IOException ex){
-            throw new MojoExecutionException(
-                      "Docker config file could not be read",
-                      ex
-            );
+        final AuthConfig.Builder authConfigBuilder;
+        try {
+          if (!isNullOrEmpty(registryUrl)) {
+            authConfigBuilder = AuthConfig.fromDockerConfig(registryUrl);
+          } else {
+            authConfigBuilder = AuthConfig.fromDockerConfig();
           }
+        } catch (IOException ex) {
+          throw new MojoExecutionException(
+              "Docker config file could not be read",
+              ex
+          );
+        }
 
-          return authConfigBuilder.build();
+        return authConfigBuilder.build();
       }
     }
     return null;


### PR DESCRIPTION
Still a bit of work in progress but this integrates https://github.com/spotify/docker-client/pull/268 into docker-maven-plugin so that the username/password from `.docker/config.json` or other paths can be used automatically by the plugin when pushing images.

I was able to test this by installing this plugin version into my local Maven repository and pushing an image to hub.docker.com, but have yet to test this with private registries or cases where there is no `.docker/config.json`, etc.

It also really needs to be tested within the unit/integration tests of the plugin before it can be merged, although this seems tricky if the `AuthConfig` class expects to read these files from a hardcoded path.