### PR TITLE
ability to pass no-cache flag when building image

### DIFF
--- a/src/main/java/com/spotify/docker/BuildMojo.java
+++ b/src/main/java/com/spotify/docker/BuildMojo.java
@@ -106,10 +106,15 @@ public class BuildMojo extends AbstractDockerMojo {
   private boolean skipDockerBuild;
 
   /**
-   * Flag to attempt to pull base images even if older images exists locally.
+   * Flag to attempt to pull base images even if older images exists locally. Sends the equivalent
+   * of `--pull=true` to Docker daemon when building the image.
    */
   @Parameter(property = "pullOnBuild", defaultValue = "false")
   private boolean pullOnBuild;
+
+  /** Set to true to pass the `--no-cache` flag to the Docker daemon when building an image. */
+  @Parameter(property = "noCache", defaultValue = "false")
+  private boolean noCache;
 
   /** Flag to push image after it is built. Defaults to false. */
   @Parameter(property = "pushImage", defaultValue = "false")
@@ -682,6 +687,9 @@ public class BuildMojo extends AbstractDockerMojo {
     final List<DockerClient.BuildParameter> buildParams = Lists.newArrayList();
     if (pullOnBuild) {
       buildParams.add(DockerClient.BuildParameter.PULL_NEWER_IMAGE);
+    }
+    if (noCache) {
+      buildParams.add(DockerClient.BuildParameter.NO_CACHE);
     }
     return buildParams.toArray(new DockerClient.BuildParameter[buildParams.size()]);
   }

--- a/src/test/java/com/spotify/docker/BuildMojoTest.java
+++ b/src/test/java/com/spotify/docker/BuildMojoTest.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.spotify.docker.client.AnsiProgressHandler;
 import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.DockerClient.BuildParameter;
 import com.spotify.docker.client.ProgressHandler;
 import com.spotify.docker.client.messages.ProgressMessage;
 
@@ -61,7 +62,6 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class BuildMojoTest extends AbstractMojoTestCase {
 
@@ -286,6 +286,30 @@ public class BuildMojoTest extends AbstractMojoTestCase {
     new File(filePath).deleteOnExit();
   }
 
+  public void testPullOnBuild() throws Exception {
+    final BuildMojo mojo = setupMojo(getTestFile("src/test/resources/pom-build-pull-on-build.xml"));
+    final DockerClient docker = mock(DockerClient.class);
+
+    mojo.execute(docker);
+
+    verify(docker).build(any(Path.class),
+        anyString(),
+        any(ProgressHandler.class),
+        eq(BuildParameter.PULL_NEWER_IMAGE));
+  }
+
+  public void testNoCache() throws Exception {
+    final BuildMojo mojo = setupMojo(getTestFile("src/test/resources/pom-build-no-cache.xml"));
+    final DockerClient docker = mock(DockerClient.class);
+
+    mojo.execute(docker);
+
+    verify(docker).build(any(Path.class),
+        anyString(),
+        any(ProgressHandler.class),
+        eq(BuildParameter.NO_CACHE));
+  }
+  
   private BuildMojo setupMojo(final File pom) throws Exception {
     final MavenExecutionRequest executionRequest = new DefaultMavenExecutionRequest();
     final ProjectBuildingRequest buildingRequest = executionRequest.getProjectBuildingRequest();

--- a/src/test/resources/pom-build-no-cache.xml
+++ b/src/test/resources/pom-build-no-cache.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>Docker Maven Plugin Test Pom</name>
+    <groupId>com.spotify</groupId>
+    <artifactId>docker-maven-plugin-test</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.1-SNAPSHOT</version>
+                <configuration>
+                    <dockerHost>http://host:2375</dockerHost>
+                    <dockerDirectory>src/test/resources/dockerDirectory</dockerDirectory>
+                    <imageName>busybox</imageName>
+
+                    <noCache>true</noCache>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/test/resources/pom-build-pull-on-build.xml
+++ b/src/test/resources/pom-build-pull-on-build.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>Docker Maven Plugin Test Pom</name>
+    <groupId>com.spotify</groupId>
+    <artifactId>docker-maven-plugin-test</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.1-SNAPSHOT</version>
+                <configuration>
+                    <dockerHost>http://host:2375</dockerHost>
+                    <dockerDirectory>src/test/resources/dockerDirectory</dockerDirectory>
+                    <imageName>busybox</imageName>
+
+                    <pullOnBuild>true</pullOnBuild>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Add configuration parameter so that the `no-cache` flag (i.e. `nocache`
in the Remote API) can be passed when building images.