### PR TITLE
Add configurable timeout and retry count for docker pushes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>eu.codearte.catch-exception</groupId>
+      <artifactId>catch-exception</artifactId>
+      <version>1.4.4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/src/main/java/com/spotify/docker/AbstractDockerMojo.java
+++ b/src/main/java/com/spotify/docker/AbstractDockerMojo.java
@@ -74,6 +74,26 @@ abstract class AbstractDockerMojo extends AbstractMojo {
   @Parameter(property = "registryUrl")
   private String registryUrl;
 
+  /**
+   * Number of retries for failing pushes, defaults to 5.
+   */
+  @Parameter(property = "retryPushCount", defaultValue = "5")
+  private int retryPushCount;
+
+  /**
+   * Retry timeout for failing pushes, defaults to 10 seconds.
+   */
+  @Parameter(property = "retryPushTimeout", defaultValue = "10000")
+  private int retryPushTimeout;
+
+  public int getRetryPushTimeout() {
+    return retryPushTimeout;
+  }
+
+  public int getRetryPushCount() {
+    return retryPushCount;
+  };
+
   public void execute() throws MojoExecutionException {
     DockerClient client = null;
     try {

--- a/src/main/java/com/spotify/docker/BuildMojo.java
+++ b/src/main/java/com/spotify/docker/BuildMojo.java
@@ -321,7 +321,7 @@ public class BuildMojo extends AbstractDockerMojo {
     }
 
     if (pushImage) {
-      pushImage(docker, imageName, getLog(), buildInfo);
+      pushImage(docker, imageName, getLog(), buildInfo, getRetryPushCount(), getRetryPushTimeout());
     }
 
     // Write image info file

--- a/src/main/java/com/spotify/docker/PushMojo.java
+++ b/src/main/java/com/spotify/docker/PushMojo.java
@@ -44,7 +44,7 @@ public class PushMojo extends AbstractDockerMojo {
 
   protected void execute(DockerClient docker)
       throws MojoExecutionException, DockerException, IOException, InterruptedException {
-    pushImage(docker, imageName, getLog(), null);
+    pushImage(docker, imageName, getLog(), null, getRetryPushCount(), getRetryPushTimeout());
   }
 
 }

--- a/src/main/java/com/spotify/docker/TagMojo.java
+++ b/src/main/java/com/spotify/docker/TagMojo.java
@@ -116,7 +116,7 @@ public class TagMojo extends AbstractDockerMojo {
     final DockerBuildInformation buildInfo = new DockerBuildInformation(normalizedName, getLog());
 
     if (pushImage) {
-      pushImage(docker, newName, getLog(), buildInfo);
+      pushImage(docker, newName, getLog(), buildInfo, getRetryPushCount(), getRetryPushTimeout());
     }
 
     writeImageInfoFile(buildInfo, tagInfoFile);

--- a/src/main/java/com/spotify/docker/Utils.java
+++ b/src/main/java/com/spotify/docker/Utils.java
@@ -26,7 +26,6 @@ import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.DockerException;
 import com.spotify.docker.client.ProgressHandler;
 import com.spotify.docker.client.messages.ProgressMessage;
-
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 
@@ -36,8 +35,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.lang.Thread.sleep;
 
 public class Utils {
+
+  public static final String PUSH_FAIL_WARN_TEMPLATE = "Failed to push %s,"
+          + " retrying in %d seconds (%d/%d).";
 
   public static String[] parseImageName(String imageName) throws MojoExecutionException {
     if (isNullOrEmpty(imageName)) {
@@ -65,20 +68,40 @@ public class Utils {
   }
 
   public static void pushImage(DockerClient docker, String imageName, Log log,
-                               final DockerBuildInformation buildInfo)
-      throws MojoExecutionException, DockerException, IOException, InterruptedException {
-      log.info("Pushing " + imageName);
+                               final DockerBuildInformation buildInfo,
+                               int retryPushCount, int retryPushTimeout)
+          throws MojoExecutionException, DockerException, IOException, InterruptedException {
+    int attempt = 0;
+    do {
+      final AnsiProgressHandler ansiProgressHandler = new AnsiProgressHandler();
+      final DigestExtractingProgressHandler handler = new DigestExtractingProgressHandler(
+              ansiProgressHandler);
 
-    final AnsiProgressHandler ansiProgressHandler = new AnsiProgressHandler();
-    final DigestExtractingProgressHandler handler = new DigestExtractingProgressHandler(
-        ansiProgressHandler);
-
-    docker.push(imageName, handler);
-
-    if (buildInfo != null) {
-      final String imageNameWithoutTag = parseImageName(imageName)[0];
-      buildInfo.setDigest(imageNameWithoutTag + "@" + handler.digest());
-    }
+      try {
+        log.info("Pushing " + imageName);
+        docker.push(imageName, handler);
+        // A concurrent push raises a generic DockerException and not
+        // the more logical ImagePushFailedException. Hence the rather
+        // wide catch clause.
+      } catch (DockerException e) {
+        if (attempt < retryPushCount) {
+          log.warn(String.format(PUSH_FAIL_WARN_TEMPLATE
+                  , imageName
+                  , retryPushTimeout / 1000
+                  , attempt + 1
+                  , retryPushCount));
+          sleep(retryPushTimeout);
+          continue;
+        } else {
+          throw e;
+        }
+      }
+      if (buildInfo != null) {
+        final String imageNameWithoutTag = parseImageName(imageName)[0];
+        buildInfo.setDigest(imageNameWithoutTag + "@" + handler.digest());
+      }
+      break;
+    } while (attempt++ <= retryPushCount);
   }
 
   public static void writeImageInfoFile(final DockerBuildInformation buildInfo,

--- a/src/test/java/com/spotify/docker/UtilsTest.java
+++ b/src/test/java/com/spotify/docker/UtilsTest.java
@@ -86,7 +86,7 @@ public class UtilsTest {
     DockerClient dockerClient = mock(DockerClient.class);
     Log log = mock(Log.class);
     final DockerBuildInformation buildInfo = mock(DockerBuildInformation.class);
-    Utils.pushImage(dockerClient, IMAGE, log, buildInfo);
+    Utils.pushImage(dockerClient, IMAGE, log, buildInfo, 0, 1);
 
     verify(dockerClient).push(eq(IMAGE), any(AnsiProgressHandler.class));
   }

--- a/src/test/resources/pom-push.xml
+++ b/src/test/resources/pom-push.xml
@@ -31,6 +31,8 @@
         <configuration>
           <dockerHost>http://host:2375</dockerHost>
           <imageName>busybox</imageName>
+          <retryPushTimeout>1</retryPushTimeout>
+          <retryPushCount>3</retryPushCount>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
By default we now try to push the image 5 times with a wait time of
10 seconds between tries.

This is a workaround for the docker registry returning HTTP 500 errors
when you push more than one image simultaneously to the same repository.
While this is mostly killing the symptoms of the actual problem it gives
us a better user experience, especially in continuous delivery pipelines
where the likelihood of pushing to the same repository is relatively high.