### PR TITLE
update docker client to recent version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
-      <version>3.3.1</version>
+      <version>3.3.4</version>
       <classifier>shaded</classifier>
     </dependency>
     <dependency>


### PR DESCRIPTION
This updates docker client to latest release (v3.3.4).
This version includes the authentication handling on private repositories on all depending images.