### PR TITLE
Issue 68 - Windows build path issue

### DIFF
--- a/src/main/java/com/spotify/docker/BuildMojo.java
+++ b/src/main/java/com/spotify/docker/BuildMojo.java
@@ -636,14 +636,15 @@ public class BuildMojo extends AbstractDockerMojo {
     if (new File(getDestination(), filePath).isFile()) {
       if (file.getParent() != null) {
         // remove file part of path
-        dest = file.getParent() + "/";
+        dest = separatorsToUnix(file.getParent()) + "/";
       } else {
         // working with a simple "ADD file.txt"
         dest = ".";
       }
     } else {
-      dest = file.getPath();
+      dest = separatorsToUnix(file.getPath());
     }
+
     return dest;
   }
 
@@ -687,15 +688,15 @@ public class BuildMojo extends AbstractDockerMojo {
         copiedPaths.add(separatorsToUnix(targetPath));
       } else {
         for (String included : includedFiles) {
-          final Path sourcePath = Paths.get(resource.getDirectory(), included);
-          final Path destPath = Paths.get(destination, targetPath, included);
+          final Path sourcePath = Paths.get(resource.getDirectory()).resolve(included);
+          final Path destPath = Paths.get(destination, targetPath).resolve(included);
           getLog().info(String.format("Copying %s -> %s", sourcePath, destPath));
           // ensure all directories exist because copy operation will fail if they don't
           Files.createDirectories(destPath.getParent());
           Files.copy(sourcePath, destPath, StandardCopyOption.REPLACE_EXISTING,
                      StandardCopyOption.COPY_ATTRIBUTES);
 
-          copiedPaths.add(separatorsToUnix(Paths.get(targetPath, included).toString()));
+          copiedPaths.add(separatorsToUnix(Paths.get(targetPath).resolve(included).toString()));
         }
       }
 


### PR DESCRIPTION
Added additional separatorsToUnix calls to correct failing docker build tests when running under windows.

Also corrected the issue with "UNC path missing sharename" that was referenced in issue 68. It seems the underlying issue is a somewhat optimistic implementation in the WindowsFileSystem.getPath method, as discussed http://stackoverflow.com/questions/33740388/paths-get-on-windows. Locally I've run the plugin with mvn clean install which was successful in passing all of the unit and integration tests under windows 7 with docker installed (the integration tests were initially failing with the UNC path missing sharename exception.