### PR TITLE
remove pinning of Guava to version 14.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,12 +142,12 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>3.2.1</version>
+      <version>3.3.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
-      <version>3.2.1</version>
+      <version>3.3.3</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
@@ -157,7 +157,7 @@
     <dependency>
       <groupId>org.apache.maven.plugin-testing</groupId>
       <artifactId>maven-plugin-testing-harness</artifactId>
-      <version>3.1.0</version>
+      <version>3.3.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -174,7 +174,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-compat</artifactId>
-      <version>3.1.1</version>
+      <version>3.3.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -209,16 +209,6 @@
     </dependency>
   </dependencies>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>14.0.1</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <build>
     <testResources>
       <testResource>
@@ -240,7 +230,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.2</version>
+        <version>3.4</version>
         <configuration>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
         </configuration>

--- a/src/test/java/com/spotify/docker/BuildMojoTest.java
+++ b/src/test/java/com/spotify/docker/BuildMojoTest.java
@@ -34,9 +34,11 @@ import com.spotify.docker.client.messages.ProgressMessage;
 import org.apache.maven.execution.DefaultMavenExecutionRequest;
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Build;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingRequest;
@@ -336,11 +338,12 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
   
   private BuildMojo setupMojo(final File pom) throws Exception {
-    final MavenExecutionRequest executionRequest = new DefaultMavenExecutionRequest();
-    final ProjectBuildingRequest buildingRequest = executionRequest.getProjectBuildingRequest();
-    final ProjectBuilder projectBuilder = this.lookup(ProjectBuilder.class);
-    final MavenProject project = projectBuilder.build(pom, buildingRequest).getProject();
+    final MavenProject project = new ProjectStub(pom);
     final MavenSession session = newMavenSession(project);
+    // for some reason the superclass method newMavenSession() does not copy properties from the
+    // project model to the session. This is needed for the use of ExpressionEvaluator in BuildMojo.
+    session.getRequest().setUserProperties(project.getModel().getProperties());
+
     final MojoExecution execution = newMojoExecution("build");
     final BuildMojo mojo = (BuildMojo) this.lookupConfiguredMojo(session, execution);
     mojo.buildDirectory = "target";

--- a/src/test/java/com/spotify/docker/ProjectStub.java
+++ b/src/test/java/com/spotify/docker/ProjectStub.java
@@ -1,0 +1,51 @@
+package com.spotify.docker;
+
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
+import org.codehaus.plexus.util.ReaderFactory;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Custom stub implementation of {@link org.apache.maven.project.MavenProject}.
+ * <p>
+ * Originally taken from <a href="https://maven.apache.org/plugin-testing/maven-plugin-testing-harness/examples/complex-mojo-parameters.html">
+ *   Maven Plugin Testing Mechanism</a> guide but adapted for our use case.</p>
+ */
+public class ProjectStub extends MavenProjectStub {
+
+  public ProjectStub(File pom) {
+    MavenXpp3Reader pomReader = new MavenXpp3Reader();
+    Model model;
+    try {
+      model = pomReader.read(ReaderFactory.newXmlReader(pom));
+      setModel(model);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    setGroupId(model.getGroupId());
+    setArtifactId(model.getArtifactId());
+    setVersion(model.getVersion());
+    setName(model.getName());
+    setUrl(model.getUrl());
+    setPackaging(model.getPackaging());
+    setBuild(model.getBuild());
+
+    List<String> compileSourceRoots = new ArrayList<>();
+    compileSourceRoots.add(getBasedir() + "/src/main/java");
+    setCompileSourceRoots(compileSourceRoots);
+
+    List<String> testCompileSourceRoots = new ArrayList<>();
+    testCompileSourceRoots.add(getBasedir() + "/src/test/java");
+    setTestCompileSourceRoots(testCompileSourceRoots);
+
+    // normalize some expressions
+    getBuild().setDirectory("${project.basedir}/target");
+    getBuild().setTestOutputDirectory(new File(getBasedir(), "target/classes").getAbsolutePath());
+  }
+}

--- a/src/test/resources/pom-push-private-repo.xml
+++ b/src/test/resources/pom-push-private-repo.xml
@@ -14,14 +14,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>15.0</version>
-    </dependency>
-  </dependencies>
-
   <build>
     <plugins>
       <plugin>

--- a/src/test/resources/pom-push.xml
+++ b/src/test/resources/pom-push.xml
@@ -14,14 +14,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>15.0</version>
-    </dependency>
-  </dependencies>
-
   <build>
     <plugins>
       <plugin>

--- a/src/test/resources/pom-removeImage.xml
+++ b/src/test/resources/pom-removeImage.xml
@@ -14,14 +14,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>15.0</version>
-    </dependency>
-  </dependencies>
-
   <build>
     <plugins>
       <plugin>

--- a/src/test/resources/pom-removeMultipleImages.xml
+++ b/src/test/resources/pom-removeMultipleImages.xml
@@ -14,14 +14,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>15.0</version>
-    </dependency>
-  </dependencies>
-
   <build>
     <plugins>
       <plugin>

--- a/src/test/resources/pom-tag1.xml
+++ b/src/test/resources/pom-tag1.xml
@@ -14,14 +14,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>15.0</version>
-    </dependency>
-  </dependencies>
-
   <build>
     <plugins>
       <plugin>

--- a/src/test/resources/pom-tag2.xml
+++ b/src/test/resources/pom-tag2.xml
@@ -14,14 +14,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>15.0</version>
-    </dependency>
-  </dependencies>
-
   <build>
     <plugins>
       <plugin>

--- a/src/test/resources/pom-tag3.xml
+++ b/src/test/resources/pom-tag3.xml
@@ -14,14 +14,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>15.0</version>
-    </dependency>
-  </dependencies>
-
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Remove the pinning of Guava to version 14.0.1 to fix #165.

Guava was held to 14.0.1 before because a combination of Plexus/Guice
code used or invoked by the maven plugin testing harness called methods
in Guava that have been removed after version (specifically
`MapMaker.makeComputingMap).

The main fix to remove that need is to avoid using that part of the
testing harness altogether by stubbing out the `MavenProject` instance
instead of trying to look it up in the Plexus container.