### PR TITLE
Update README.md for issue #171

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,9 @@ Then when pushing the image with either `docker:build -DpushImage` or
 `docker:push`, the docker daemon will push to `registry.example.com`.
 
 Alternatively, if you wish to use a short name in `docker:build` you can use
-`docker:tag` to tag the just-built image with the full registry hostname. For
-example:
+`docker:tag -DpushImage` to tag the just-built image with the full registry hostname and push it. It's important to use the `pushImage` flag as using `docker:push` independently will attempt to push the original image. 
+
+For example:
 
 ```xml
 <plugin>


### PR DESCRIPTION
add that you need to use the -DpushImage flag on docker:tag for a private registry as docker:push will use the original image. (issue #171)