### PR TITLE
Support for docker command line option --build-arg

### DIFF
--- a/src/main/java/com/spotify/docker/BuildMojo.java
+++ b/src/main/java/com/spotify/docker/BuildMojo.java
@@ -21,6 +21,8 @@
 
 package com.spotify.docker;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -52,6 +54,8 @@ import org.eclipse.jgit.api.errors.GitAPIException;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -233,6 +237,9 @@ public class BuildMojo extends AbstractDockerMojo {
   @Parameter(defaultValue = "${project}")
   private MavenProject mavenProject;
 
+  @Parameter(property = "dockerBuildArgs")
+  private Map<String, String> buildArgs;  
+  
   private PluginParameterExpressionEvaluator expressionEvaluator;
 
   public BuildMojo() {
@@ -771,13 +778,18 @@ public class BuildMojo extends AbstractDockerMojo {
     return path.replace(WINDOWS_SEPARATOR, UNIX_SEPARATOR);
   }
 
-  private DockerClient.BuildParam[] buildParams() {
+  private DockerClient.BuildParam[] buildParams() 
+    throws UnsupportedEncodingException, JsonProcessingException {
     final List<DockerClient.BuildParam> buildParams = Lists.newArrayList();
     if (pullOnBuild) {
       buildParams.add(DockerClient.BuildParam.pullNewerImage());
     }
     if (noCache) {
       buildParams.add(DockerClient.BuildParam.noCache());
+    }
+    if (!buildArgs.isEmpty()) {
+      buildParams.add(DockerClient.BuildParam.create("buildargs", 
+        URLEncoder.encode(new ObjectMapper().writeValueAsString(buildArgs), "UTF-8")));
     }
     return buildParams.toArray(new DockerClient.BuildParam[buildParams.size()]);
   }

--- a/src/main/java/com/spotify/docker/BuildMojo.java
+++ b/src/main/java/com/spotify/docker/BuildMojo.java
@@ -97,6 +97,11 @@ public class BuildMojo extends AbstractDockerMojo {
   private static final char WINDOWS_SEPARATOR = '\\';
 
   /**
+   * Json Object Mapper to encode arguments map 
+   */
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  
+  /**
    * Directory containing the Dockerfile. If the value is not set, the plugin will generate a
    * Dockerfile using the required baseImage value, plus the optional entryPoint, cmd and maintainer
    * values. If this value is set the plugin will use the Dockerfile in the specified folder.
@@ -789,7 +794,7 @@ public class BuildMojo extends AbstractDockerMojo {
     }
     if (!buildArgs.isEmpty()) {
       buildParams.add(DockerClient.BuildParam.create("buildargs", 
-        URLEncoder.encode(new ObjectMapper().writeValueAsString(buildArgs), "UTF-8")));
+        URLEncoder.encode(OBJECT_MAPPER.writeValueAsString(buildArgs), "UTF-8")));
     }
     return buildParams.toArray(new DockerClient.BuildParam[buildParams.size()]);
   }

--- a/src/test/java/com/spotify/docker/BuildMojoTest.java
+++ b/src/test/java/com/spotify/docker/BuildMojoTest.java
@@ -200,6 +200,21 @@ public class BuildMojoTest extends AbstractMojoTestCase {
     assertFilesCopied();
   }
 
+  public void testBuildWithDockerDirectoryWithArgs() throws Exception {
+    final File pom = getTestFile("src/test/resources/pom-build-docker-directory-args.xml");
+    assertNotNull("Null pom.xml", pom);
+    assertTrue("pom.xml does not exist", pom.exists());
+
+    final BuildMojo mojo = setupMojo(pom);
+    final DockerClient docker = mock(DockerClient.class);
+
+    mojo.execute(docker);
+    verify(docker).build(eq(Paths.get("target/docker")), eq("busybox"),
+                         any(AnsiProgressHandler.class), 
+                         eq(DockerClient.BuildParam.create("buildargs", "%7B%22VERSION%22%3A%220.1%22%7D")));
+    assertFilesCopied();
+  }
+  
   public void testBuildWithPush() throws Exception {
     final File pom = getTestFile("src/test/resources/pom-build-push.xml");
     assertNotNull("Null pom.xml", pom);

--- a/src/test/resources/dockerDirectoryArgs/Dockerfile
+++ b/src/test/resources/dockerDirectoryArgs/Dockerfile
@@ -1,7 +1,0 @@
-FROM       busybox
-MAINTAINER John Doe "user@spotify.com"
-
-ARG VERSION
-RUN echo "${VERSION}" >> /build-version
-
-RUN date >> /build-timestamp

--- a/src/test/resources/dockerDirectoryArgs/Dockerfile
+++ b/src/test/resources/dockerDirectoryArgs/Dockerfile
@@ -1,0 +1,7 @@
+FROM       busybox
+MAINTAINER John Doe "user@spotify.com"
+
+ARG VERSION
+RUN echo "${VERSION}" >> /build-version
+
+RUN date >> /build-timestamp

--- a/src/test/resources/pom-build-docker-directory-args.xml
+++ b/src/test/resources/pom-build-docker-directory-args.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <name>Docker Maven Plugin Test Pom</name>
+  <groupId>com.spotify</groupId>
+  <artifactId>docker-maven-plugin-test</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <configuration>
+          <dockerHost>http://host:2375</dockerHost>
+          <!-- test that dockerDirectory works correctly -->
+          <dockerDirectory>src/test/resources/dockerDirectoryArgs</dockerDirectory>
+          <imageName>busybox</imageName>
+          <buildArgs>
+            <VERSION>0.1</VERSION>          
+          </buildArgs>
+          <resources>
+            <resource>
+              <!-- test we handle all elements correctly -->
+              <targetPath>resources</targetPath>
+              <directory>src/test/resources/copy1</directory>
+              <include>**/*.xml</include>
+              <exclude>**/*exclude*</exclude>
+            </resource>
+            <resource>
+              <!-- test we handle missing elements correctly -->
+              <directory>src/test/resources/copy2</directory>
+            </resource>
+          </resources>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/pom-build-docker-directory-args.xml
+++ b/src/test/resources/pom-build-docker-directory-args.xml
@@ -19,7 +19,7 @@
         <configuration>
           <dockerHost>http://host:2375</dockerHost>
           <!-- test that dockerDirectory works correctly -->
-          <dockerDirectory>src/test/resources/dockerDirectoryArgs</dockerDirectory>
+          <dockerDirectory>src/test/resources/dockerDirectory</dockerDirectory>
           <imageName>busybox</imageName>
           <buildArgs>
             <VERSION>0.1</VERSION>          


### PR DESCRIPTION
This pull request can fix the issue #184 and allow to set Build Args in the pom.

Here is an example:
```
<groupId>com.spotify</groupId>
<artifactId>docker-maven-plugin</artifactId>
<configuration>
    <imageName>myImage</imageName>
    <dockerDirectory>${project.basedir}/src/main/resources</dockerDirectory>
    <imageTags>
        <tag>${project.version}</tag>
    </imageTags>
    <buildArgs>
         <HTTP_PROXY>http://x.x.x.x:x</HTTP_PROXY>
         <VERSION>${project.version}</VERSION>        
    </buildArgs>
</configuration>
```

