### PR TITLE
Add skipDockerPush and skipDocker properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,11 @@ will need to do this binding so the image gets built when maven is run from the 
       </executions>
     </plugin>
 
-You can skip Docker build with `-DskipDockerBuild` and skip Docker tag with `-DskipDockerTag`.
+You can skip Docker goals bound to Maven phases with:
+
+* `-DskipDockerBuild` to skip image build
+* `-DskipDockerTag` to skip image tag
+* `-DskipDockerPush` to skip image push
 
 To remove the image named `foobar` run the following command:
 

--- a/README.md
+++ b/README.md
@@ -197,10 +197,11 @@ You can skip Docker goals bound to Maven phases with:
 * `-DskipDockerBuild` to skip image build
 * `-DskipDockerTag` to skip image tag
 * `-DskipDockerPush` to skip image push
+* `-DskipDocker` to skip any Docker goals
 
 To remove the image named `foobar` run the following command:
 
-  mvn docker:removeImage -DimageName=foobar
+    mvn docker:removeImage -DimageName=foobar
 
 For a complete list of configuration options run:
 `mvn com.spotify:docker-maven-plugin:<version>:help -Ddetail=true`

--- a/pom.xml
+++ b/pom.xml
@@ -198,13 +198,19 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>2.0.0</version>
+      <version>2.3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <version>4.1.6.RELEASE</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.19</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/spotify/docker/AbstractDockerMojo.java
+++ b/src/main/java/com/spotify/docker/AbstractDockerMojo.java
@@ -97,6 +97,13 @@ abstract class AbstractDockerMojo extends AbstractMojo {
   @Parameter(property = "retryPushTimeout", defaultValue = "10000")
   private int retryPushTimeout;
 
+  /**
+   * Flag to skip docker goal, making goal a no-op. This can be useful when docker goal
+   * is bound to Maven phase, and you want to skip Docker command. Defaults to false.
+   */
+  @Parameter(property = "skipDocker", defaultValue = "false")
+  private boolean skipDocker;
+
   public int getRetryPushTimeout() {
     return retryPushTimeout;
   }
@@ -105,7 +112,14 @@ abstract class AbstractDockerMojo extends AbstractMojo {
     return retryPushCount;
   };
 
+  @Override
   public void execute() throws MojoExecutionException {
+
+    if (skipDocker) {
+      getLog().info("Skipping docker goal");
+      return;
+    }
+
     DockerClient client = null;
     try {
       final DefaultDockerClient.Builder builder = getBuilder();

--- a/src/main/java/com/spotify/docker/AbstractDockerMojo.java
+++ b/src/main/java/com/spotify/docker/AbstractDockerMojo.java
@@ -104,6 +104,13 @@ abstract class AbstractDockerMojo extends AbstractMojo {
   @Parameter(property = "skipDocker", defaultValue = "false")
   private boolean skipDocker;
 
+  /**
+   * Flag to skip docker push, making push goal a no-op. This can be useful when docker:push
+   * is bound to deploy goal, and you want to deploy a jar but not a container. Defaults to false.
+   */
+  @Parameter(property = "skipDockerPush", defaultValue = "false")
+  private boolean skipDockerPush;
+
   public int getRetryPushTimeout() {
     return retryPushTimeout;
   }
@@ -111,6 +118,14 @@ abstract class AbstractDockerMojo extends AbstractMojo {
   public int getRetryPushCount() {
     return retryPushCount;
   };
+
+  public boolean isSkipDocker() {
+    return skipDocker;
+  }
+
+  public boolean isSkipDockerPush() {
+    return skipDockerPush;
+  }
 
   @Override
   public void execute() throws MojoExecutionException {
@@ -120,38 +135,38 @@ abstract class AbstractDockerMojo extends AbstractMojo {
       return;
     }
 
-    DockerClient client = null;
-    try {
-      final DefaultDockerClient.Builder builder = getBuilder();
-
-      final String dockerHost = rawDockerHost();
-      if (!isNullOrEmpty(dockerHost)) {
-        builder.uri(dockerHost);
-      }
-      final Optional<DockerCertificates> certs = dockerCertificates();
-      if (certs.isPresent()) {
-        builder.dockerCertificates(certs.get());
-      }
-
-      final AuthConfig authConfig = authConfig();
-      if (authConfig != null) {
-        builder.authConfig(authConfig);
-      }
-
-      client = builder.build();
+    try (DockerClient client = buildDockerClient()) {
       execute(client);
     } catch (Exception e) {
       throw new MojoExecutionException("Exception caught", e);
-    } finally {
-      if (client != null) {
-        client.close();
-      }
     }
   }
 
   protected DefaultDockerClient.Builder getBuilder() throws DockerCertificateException {
     return DefaultDockerClient.fromEnv()
       .readTimeoutMillis(0);
+  }
+
+  protected DockerClient buildDockerClient()
+      throws DockerCertificateException, SecDispatcherException, MojoExecutionException {
+
+    final DefaultDockerClient.Builder builder = getBuilder();
+
+    final String dockerHost = rawDockerHost();
+    if (!isNullOrEmpty(dockerHost)) {
+      builder.uri(dockerHost);
+    }
+    final Optional<DockerCertificates> certs = dockerCertificates();
+    if (certs.isPresent()) {
+      builder.dockerCertificates(certs.get());
+    }
+
+    final AuthConfig authConfig = authConfig();
+    if (authConfig != null) {
+      builder.authConfig(authConfig);
+    }
+
+    return builder.build();
   }
 
   protected abstract void execute(final DockerClient dockerClient) throws Exception;

--- a/src/main/java/com/spotify/docker/BuildMojo.java
+++ b/src/main/java/com/spotify/docker/BuildMojo.java
@@ -271,6 +271,10 @@ public class BuildMojo extends AbstractDockerMojo {
     return forceTags;
   }
 
+  public boolean isSkipDockerBuild() {
+    return skipDockerBuild;
+  }
+
   @Override
   protected void execute(final DockerClient docker)
       throws MojoExecutionException, GitAPIException, IOException, DockerException,
@@ -356,11 +360,12 @@ public class BuildMojo extends AbstractDockerMojo {
 
     // Push specific tags specified in pom rather than all images
     if (pushImageTag) {
-      pushImageTag(docker, imageName, imageTags, getLog());
+      pushImageTag(docker, imageName, imageTags, getLog(), isSkipDockerPush());
     }
 
     if (pushImage) {
-      pushImage(docker, imageName, getLog(), buildInfo, getRetryPushCount(), getRetryPushTimeout());
+      pushImage(docker, imageName, getLog(), buildInfo, getRetryPushCount(), getRetryPushTimeout(),
+          isSkipDockerPush());
     }
 
     // Write image info file
@@ -800,4 +805,6 @@ public class BuildMojo extends AbstractDockerMojo {
     }
     return buildParams.toArray(new DockerClient.BuildParam[buildParams.size()]);
   }
+
+
 }

--- a/src/main/java/com/spotify/docker/PushMojo.java
+++ b/src/main/java/com/spotify/docker/PushMojo.java
@@ -42,23 +42,12 @@ public class PushMojo extends AbstractDockerMojo {
   @Parameter(property = "imageName", required = true)
   private String imageName;
 
-  /**
-   * Flag to skip docker push, making push goal a no-op. This can be useful when docker:push
-   * is bound to deploy goal, and you want to deploy a jar but not a container. Defaults to false.
-   */
-  @Parameter(property = "skipDockerPush", defaultValue = "false")
-  private boolean skipDockerPush;
-
   @Override
   protected void execute(DockerClient docker)
       throws MojoExecutionException, DockerException, IOException, InterruptedException {
 
-    if (skipDockerPush) {
-      getLog().info("Skipping docker push");
-      return;
-    }
-
-    pushImage(docker, imageName, getLog(), null, getRetryPushCount(), getRetryPushTimeout());
+    pushImage(docker, imageName, getLog(), null, getRetryPushCount(), getRetryPushTimeout(),
+        isSkipDockerPush());
   }
 
 }

--- a/src/main/java/com/spotify/docker/PushMojo.java
+++ b/src/main/java/com/spotify/docker/PushMojo.java
@@ -42,8 +42,22 @@ public class PushMojo extends AbstractDockerMojo {
   @Parameter(property = "imageName", required = true)
   private String imageName;
 
+  /**
+   * Flag to skip docker push, making push goal a no-op. This can be useful when docker:push
+   * is bound to deploy goal, and you want to deploy a jar but not a container. Defaults to false.
+   */
+  @Parameter(property = "skipDockerPush", defaultValue = "false")
+  private boolean skipDockerPush;
+
+  @Override
   protected void execute(DockerClient docker)
       throws MojoExecutionException, DockerException, IOException, InterruptedException {
+
+    if (skipDockerPush) {
+      getLog().info("Skipping docker push");
+      return;
+    }
+
     pushImage(docker, imageName, getLog(), null, getRetryPushCount(), getRetryPushTimeout());
   }
 

--- a/src/main/java/com/spotify/docker/RemoveImageMojo.java
+++ b/src/main/java/com/spotify/docker/RemoveImageMojo.java
@@ -56,6 +56,7 @@ public class RemoveImageMojo extends AbstractDockerMojo {
   @Parameter(property = "dockerImageTags")
   private List<String> imageTags;
 
+  @Override
   protected void execute(final DockerClient docker)
       throws MojoExecutionException, DockerException, IOException, InterruptedException {
     final String imageNameWithoutTag = parseImageName(imageName)[0];

--- a/src/main/java/com/spotify/docker/TagMojo.java
+++ b/src/main/java/com/spotify/docker/TagMojo.java
@@ -87,6 +87,10 @@ public class TagMojo extends AbstractDockerMojo {
   @Parameter(property = "useGitCommitId", defaultValue = "false")
   private boolean useGitCommitId;
 
+  public boolean isSkipDockerTag() {
+    return skipDockerTag;
+  }
+
   @Override
   protected void execute(DockerClient docker)
       throws MojoExecutionException, DockerException,

--- a/src/main/java/com/spotify/docker/TagMojo.java
+++ b/src/main/java/com/spotify/docker/TagMojo.java
@@ -116,7 +116,8 @@ public class TagMojo extends AbstractDockerMojo {
     final DockerBuildInformation buildInfo = new DockerBuildInformation(normalizedName, getLog());
 
     if (pushImage) {
-      pushImage(docker, newName, getLog(), buildInfo, getRetryPushCount(), getRetryPushTimeout());
+      pushImage(docker, newName, getLog(), buildInfo, getRetryPushCount(), getRetryPushTimeout(),
+          isSkipDockerPush());
     }
 
     writeImageInfoFile(buildInfo, tagInfoFile);

--- a/src/main/java/com/spotify/docker/Utils.java
+++ b/src/main/java/com/spotify/docker/Utils.java
@@ -70,8 +70,14 @@ public class Utils {
 
   public static void pushImage(DockerClient docker, String imageName, Log log,
                                final DockerBuildInformation buildInfo,
-                               int retryPushCount, int retryPushTimeout)
+                               int retryPushCount, int retryPushTimeout, boolean skipPush)
           throws MojoExecutionException, DockerException, IOException, InterruptedException {
+
+    if (skipPush) {
+      log.info("Skipping docker push");
+      return;
+    }
+
     int attempt = 0;
     do {
       final AnsiProgressHandler ansiProgressHandler = new AnsiProgressHandler();
@@ -107,14 +113,19 @@ public class Utils {
 
   // push just the tags listed in the pom rather than all images using imageName
   public static void pushImageTag(DockerClient docker, String imageName,
-                                List<String> imageTags, Log log)
+                                List<String> imageTags, Log log, boolean skipPush)
       throws MojoExecutionException, DockerException, IOException, InterruptedException {
-      // tags should not be empty if you have specified the option to push tags
-      if (imageTags.isEmpty()) {
-        throw new MojoExecutionException("You have used option \"pushImageTag\" but have"
-                                         + " not specified an \"imageTag\" in your"
-                                         + " docker-maven-client's plugin configuration");
-      }
+
+    if (skipPush) {
+      log.info("Skipping docker push");
+      return;
+    }
+    // tags should not be empty if you have specified the option to push tags
+    if (imageTags.isEmpty()) {
+      throw new MojoExecutionException("You have used option \"pushImageTag\" but have"
+                                       + " not specified an \"imageTag\" in your"
+                                       + " docker-maven-client's plugin configuration");
+    }
     final CompositeImageName compositeImageName = CompositeImageName.create(imageName, imageTags);
     for (final String imageTag : compositeImageName.getImageTags()) {
       final String imageNameWithTag = compositeImageName.getName() + ":" + imageTag;

--- a/src/test/java/com/spotify/docker/BuildMojoTest.java
+++ b/src/test/java/com/spotify/docker/BuildMojoTest.java
@@ -53,6 +53,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 
+import static com.spotify.docker.TestUtils.getPomAndAssertExists;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
@@ -60,6 +61,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class BuildMojoTest extends AbstractMojoTestCase {
 
@@ -157,9 +159,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
 
   //tests the docker volumes feature
   public void testBuildWithDockerVolumes() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-build-docker-volumes.xml");
-    assertNotNull("Null pom.xml", pom);
-    assertTrue("pom.xml does not exist", pom.exists());
+    final File pom = getPomAndAssertExists("/pom-build-docker-volumes.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -174,9 +174,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithDockerLabels() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-build-docker-labels.xml");
-    assertNotNull("Null pom.xml", pom);
-    assertTrue("pom.xml does not exist", pom.exists());
+    final File pom = getPomAndAssertExists("/pom-build-docker-labels.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -191,9 +189,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithDockerDirectory() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-build-docker-directory.xml");
-    assertNotNull("Null pom.xml", pom);
-    assertTrue("pom.xml does not exist", pom.exists());
+    final File pom = getPomAndAssertExists("/pom-build-docker-directory.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -205,9 +201,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithDockerDirectoryWithArgs() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-build-docker-directory-args.xml");
-    assertNotNull("Null pom.xml", pom);
-    assertTrue("pom.xml does not exist", pom.exists());
+    final File pom = getPomAndAssertExists("/pom-build-docker-directory-args.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -221,9 +215,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithPush() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-build-push.xml");
-    assertNotNull("Null pom.xml", pom);
-    assertTrue("pom.xml does not exist", pom.exists());
+    final File pom = getPomAndAssertExists("/pom-build-push.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -249,9 +241,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testDigestWrittenOnBuildWithPush() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-build-push.xml");
-    assertNotNull("Null pom.xml", pom);
-    assertTrue("pom.xml does not exist", pom.exists());
+    final File pom = getPomAndAssertExists("/pom-build-push.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -285,9 +275,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testDigestWrittenOnBuildWithPushAndExplicitTag() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-build-push-with-tag.xml");
-    assertNotNull("Null pom.xml", pom);
-    assertTrue("pom.xml does not exist", pom.exists());
+    final File pom = getPomAndAssertExists("/pom-build-push-with-tag.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -321,9 +309,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithPull() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-build-pull.xml");
-    assertNotNull("Null pom.xml", pom);
-    assertTrue("pom.xml does not exist", pom.exists());
+    final File pom = getPomAndAssertExists("/pom-build-pull.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -334,9 +320,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithPushTag() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-build-push-tag.xml");
-    assertNotNull("Null pom.xml", pom);
-    assertTrue("pom.xml does not exist", pom.exists());
+    final File pom = getPomAndAssertExists("/pom-build-push-tag.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -348,9 +332,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithMultiplePushTag() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-build-push-tags.xml");
-    assertNotNull("Null pom.xml", pom);
-    assertTrue("pom.xml does not exist", pom.exists());
+    final File pom = getPomAndAssertExists("/pom-build-push-tags.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -401,9 +383,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithInvalidPushTag() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-build-missing-push-tags.xml");
-    assertNotNull("Null pom.xml", pom);
-    assertTrue("pom.xml does not exist", pom.exists());
+    final File pom = getPomAndAssertExists("/pom-build-missing-push-tags.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -421,9 +401,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithGeneratedDockerfile() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-build-generated-dockerfile.xml");
-    assertNotNull("Null pom.xml", pom);
-    assertTrue("pom.xml does not exist", pom.exists());
+    final File pom = getPomAndAssertExists("/pom-build-generated-dockerfile.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -437,10 +415,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithGeneratedDockerfileWithSquashCommands() throws Exception {
-      final File pom = getTestFile(
-          "src/test/resources/pom-build-generated-dockerfile-with-squash-commands.xml");
-      assertNotNull("Null pom.xml", pom);
-      assertTrue("pom.xml does not exist", pom.exists());
+      final File pom = getPomAndAssertExists("/pom-build-generated-dockerfile-with-squash-commands.xml");
 
       final BuildMojo mojo = setupMojo(pom);
       final DockerClient docker = mock(DockerClient.class);
@@ -454,7 +429,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
     }
 
   public void testBuildGeneratedDockerFile_CopiesEntireDirectory() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-build-copy-entire-directory.xml");
+    final File pom = getPomAndAssertExists("/pom-build-copy-entire-directory.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -477,9 +452,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithProfile() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-build-with-profile.xml");
-    assertNotNull("Null pom.xml", pom);
-    assertTrue("pom.xml does not exist", pom.exists());
+    final File pom = getPomAndAssertExists("/pom-build-with-profile.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -495,9 +468,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithInvalidProfile() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-build-with-invalid-profile.xml");
-    assertNotNull("Null pom.xml", pom);
-    assertTrue("pom.xml does not exist", pom.exists());
+    final File pom = getPomAndAssertExists("/pom-build-with-invalid-profile.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -517,9 +488,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
    * "image_info.json".
    */
   public void testBuildWithTagInfoFileInSameDirectory() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-build-with-tagInfoFile.xml");
-    assertNotNull("Null pom.xml", pom);
-    assertTrue("pom.xml does not exist", pom.exists());
+    final File pom = getPomAndAssertExists("/pom-build-with-tagInfoFile.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -534,7 +503,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testPullOnBuild() throws Exception {
-    final BuildMojo mojo = setupMojo(getTestFile("src/test/resources/pom-build-pull-on-build.xml"));
+    final BuildMojo mojo = setupMojo(getPomAndAssertExists("/pom-build-pull-on-build.xml"));
     final DockerClient docker = mock(DockerClient.class);
 
     mojo.execute(docker);
@@ -546,7 +515,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testNoCache() throws Exception {
-    final BuildMojo mojo = setupMojo(getTestFile("src/test/resources/pom-build-no-cache.xml"));
+    final BuildMojo mojo = setupMojo(getPomAndAssertExists("/pom-build-no-cache.xml"));
     final DockerClient docker = mock(DockerClient.class);
 
     mojo.execute(docker);
@@ -555,6 +524,41 @@ public class BuildMojoTest extends AbstractMojoTestCase {
         anyString(),
         any(ProgressHandler.class),
         eq(BuildParam.noCache()));
+  }
+
+  public void testBuildWithSkipDockerBuild() throws Exception {
+    final BuildMojo mojo = setupMojo(getPomAndAssertExists("/pom-build-skip-build.xml"));
+    assertThat(mojo.isSkipDockerBuild()).isTrue();
+
+    final DockerClient docker = mock(DockerClient.class);
+    mojo.execute(docker);
+
+    verify(docker, never())
+        .build(any(Path.class), anyString(), any(AnsiProgressHandler.class));
+    verify(docker, never())
+        .push(anyString(), any(AnsiProgressHandler.class));
+  }
+
+  public void testBuildWithSkipDocker() throws Exception {
+    final BuildMojo mojo = setupMojo(getPomAndAssertExists("/pom-build-skip-docker.xml"));
+    assertThat(mojo.isSkipDocker()).isTrue();
+
+    BuildMojo mojoSpy = spy(mojo);
+    mojo.execute();
+    verify(mojoSpy, never()).execute(any(DockerClient.class));
+  }
+
+  public void testBuildWithPushTagAndSkipDockerPush() throws Exception {
+    final BuildMojo mojo = setupMojo(getPomAndAssertExists("/pom-build-skip-push.xml"));
+    assertThat(mojo.isSkipDockerPush()).isTrue();
+
+    final DockerClient docker = mock(DockerClient.class);
+    mojo.execute(docker);
+
+    verify(docker)
+        .build(eq(Paths.get("target/docker")), eq("busybox"), any(AnsiProgressHandler.class));
+    verify(docker, never())
+        .push(anyString(), any(AnsiProgressHandler.class));
   }
 
   private BuildMojo setupMojo(final File pom) throws Exception {

--- a/src/test/java/com/spotify/docker/BuildMojoTest.java
+++ b/src/test/java/com/spotify/docker/BuildMojoTest.java
@@ -415,7 +415,8 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithGeneratedDockerfileWithSquashCommands() throws Exception {
-      final File pom = getPomAndAssertExists("/pom-build-generated-dockerfile-with-squash-commands.xml");
+      final File pom = getPomAndAssertExists(
+          "/pom-build-generated-dockerfile-with-squash-commands.xml");
 
       final BuildMojo mojo = setupMojo(pom);
       final DockerClient docker = mock(DockerClient.class);
@@ -543,7 +544,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
     final BuildMojo mojo = setupMojo(getPomAndAssertExists("/pom-build-skip-docker.xml"));
     assertThat(mojo.isSkipDocker()).isTrue();
 
-    BuildMojo mojoSpy = spy(mojo);
+    final BuildMojo mojoSpy = spy(mojo);
     mojo.execute();
     verify(mojoSpy, never()).execute(any(DockerClient.class));
   }

--- a/src/test/java/com/spotify/docker/BuildMojoTest.java
+++ b/src/test/java/com/spotify/docker/BuildMojoTest.java
@@ -53,14 +53,16 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 
-import static com.spotify.docker.TestUtils.getPomAndAssertExists;
+import static com.spotify.docker.TestUtils.getPom;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.spy;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class BuildMojoTest extends AbstractMojoTestCase {
@@ -159,7 +161,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
 
   //tests the docker volumes feature
   public void testBuildWithDockerVolumes() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-build-docker-volumes.xml");
+    final File pom = getPom("/pom-build-docker-volumes.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -174,7 +176,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithDockerLabels() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-build-docker-labels.xml");
+    final File pom = getPom("/pom-build-docker-labels.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -189,7 +191,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithDockerDirectory() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-build-docker-directory.xml");
+    final File pom = getPom("/pom-build-docker-directory.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -201,7 +203,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithDockerDirectoryWithArgs() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-build-docker-directory-args.xml");
+    final File pom = getPom("/pom-build-docker-directory-args.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -215,7 +217,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithPush() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-build-push.xml");
+    final File pom = getPom("/pom-build-push.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -227,9 +229,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithPushCompositeImageNameNoTag() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-build-push-composite.xml");
-    assertNotNull("Null pom.xml", pom);
-    assertTrue("pom.xml does not exist", pom.exists());
+    final File pom = getPom("/pom-build-push-composite.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -241,7 +241,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testDigestWrittenOnBuildWithPush() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-build-push.xml");
+    final File pom = getPom("/pom-build-push.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -275,7 +275,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testDigestWrittenOnBuildWithPushAndExplicitTag() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-build-push-with-tag.xml");
+    final File pom = getPom("/pom-build-push-with-tag.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -309,7 +309,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithPull() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-build-pull.xml");
+    final File pom = getPom("/pom-build-pull.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -320,7 +320,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithPushTag() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-build-push-tag.xml");
+    final File pom = getPom("/pom-build-push-tag.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -332,7 +332,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithMultiplePushTag() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-build-push-tags.xml");
+    final File pom = getPom("/pom-build-push-tags.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -346,7 +346,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithMultiplePushTagButNoTagsSpecified() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-build-push-tags-no-tags-provided.xml");
+    final File pom = getPom("/pom-build-push-tags-no-tags-provided.xml");
     assertNotNull("Null pom.xml", pom);
     assertTrue("pom.xml does not exist", pom.exists());
 
@@ -366,7 +366,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithMultipleCompositePushTag() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-build-push-tags-composite.xml");
+    final File pom = getPom("/pom-build-push-tags-composite.xml");
     assertNotNull("Null pom.xml", pom);
     assertTrue("pom.xml does not exist", pom.exists());
 
@@ -383,7 +383,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithInvalidPushTag() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-build-missing-push-tags.xml");
+    final File pom = getPom("/pom-build-missing-push-tags.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -401,7 +401,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithGeneratedDockerfile() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-build-generated-dockerfile.xml");
+    final File pom = getPom("/pom-build-generated-dockerfile.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -415,7 +415,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithGeneratedDockerfileWithSquashCommands() throws Exception {
-      final File pom = getPomAndAssertExists(
+      final File pom = getPom(
           "/pom-build-generated-dockerfile-with-squash-commands.xml");
 
       final BuildMojo mojo = setupMojo(pom);
@@ -430,7 +430,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
     }
 
   public void testBuildGeneratedDockerFile_CopiesEntireDirectory() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-build-copy-entire-directory.xml");
+    final File pom = getPom("/pom-build-copy-entire-directory.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -453,7 +453,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithProfile() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-build-with-profile.xml");
+    final File pom = getPom("/pom-build-with-profile.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -469,7 +469,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithInvalidProfile() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-build-with-invalid-profile.xml");
+    final File pom = getPom("/pom-build-with-invalid-profile.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -489,7 +489,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
    * "image_info.json".
    */
   public void testBuildWithTagInfoFileInSameDirectory() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-build-with-tagInfoFile.xml");
+    final File pom = getPom("/pom-build-with-tagInfoFile.xml");
 
     final BuildMojo mojo = setupMojo(pom);
     final DockerClient docker = mock(DockerClient.class);
@@ -504,7 +504,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testPullOnBuild() throws Exception {
-    final BuildMojo mojo = setupMojo(getPomAndAssertExists("/pom-build-pull-on-build.xml"));
+    final BuildMojo mojo = setupMojo(getPom("/pom-build-pull-on-build.xml"));
     final DockerClient docker = mock(DockerClient.class);
 
     mojo.execute(docker);
@@ -516,7 +516,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testNoCache() throws Exception {
-    final BuildMojo mojo = setupMojo(getPomAndAssertExists("/pom-build-no-cache.xml"));
+    final BuildMojo mojo = setupMojo(getPom("/pom-build-no-cache.xml"));
     final DockerClient docker = mock(DockerClient.class);
 
     mojo.execute(docker);
@@ -528,7 +528,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithSkipDockerBuild() throws Exception {
-    final BuildMojo mojo = setupMojo(getPomAndAssertExists("/pom-build-skip-build.xml"));
+    final BuildMojo mojo = setupMojo(getPom("/pom-build-skip-build.xml"));
     assertThat(mojo.isSkipDockerBuild()).isTrue();
 
     final DockerClient docker = mock(DockerClient.class);
@@ -541,7 +541,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithSkipDocker() throws Exception {
-    final BuildMojo mojo = setupMojo(getPomAndAssertExists("/pom-build-skip-docker.xml"));
+    final BuildMojo mojo = setupMojo(getPom("/pom-build-skip-docker.xml"));
     assertThat(mojo.isSkipDocker()).isTrue();
 
     final BuildMojo mojoSpy = spy(mojo);
@@ -550,7 +550,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
   }
 
   public void testBuildWithPushTagAndSkipDockerPush() throws Exception {
-    final BuildMojo mojo = setupMojo(getPomAndAssertExists("/pom-build-skip-push.xml"));
+    final BuildMojo mojo = setupMojo(getPom("/pom-build-skip-push.xml"));
     assertThat(mojo.isSkipDockerPush()).isTrue();
 
     final DockerClient docker = mock(DockerClient.class);

--- a/src/test/java/com/spotify/docker/PushMojoTest.java
+++ b/src/test/java/com/spotify/docker/PushMojoTest.java
@@ -73,16 +73,18 @@ public class PushMojoTest extends AbstractMojoTestCase {
     final DockerClient docker = mock(DockerClient.class);
 
     mojo.execute(docker);
-    verify(docker).push(eq("dxia3/docker-maven-plugin-auth"), any(AnsiProgressHandler.class));
+    verify(docker)
+        .push(eq("dxia3/docker-maven-plugin-auth"), any(AnsiProgressHandler.class));
   }
 
   public void testPushSkipPush() throws Exception {
 
-    final PushMojo mojo = (PushMojo) lookupMojo("push", getPomAndAssertExists("/pom-push-skip-push.xml"));
+    final PushMojo mojo = (PushMojo) lookupMojo("push",
+        getPomAndAssertExists("/pom-push-skip-push.xml"));
     assertThat(mojo).isNotNull();
     assertThat(mojo.isSkipDockerPush()).isTrue();
 
-    final DockerClient docker = mock(DockerClient.class);
+   final DockerClient docker = mock(DockerClient.class);
     mojo.execute(docker);
 
     verify(docker, never())
@@ -90,11 +92,12 @@ public class PushMojoTest extends AbstractMojoTestCase {
   }
 
   public void testPushSkipDocker() throws Exception {
-    final PushMojo mojo = (PushMojo) lookupMojo("push", getPomAndAssertExists("/pom-push-skip-docker.xml"));
+    final PushMojo mojo = (PushMojo) lookupMojo("push",
+        getPomAndAssertExists("/pom-push-skip-docker.xml"));
     assertThat(mojo).isNotNull();
     assertThat(mojo.isSkipDocker()).isTrue();
 
-    PushMojo mojoSpy = spy(mojo);
+    final PushMojo mojoSpy = spy(mojo);
     mojo.execute();
 
     verify(mojoSpy, never()).execute(any(DockerClient.class));

--- a/src/test/java/com/spotify/docker/PushMojoTest.java
+++ b/src/test/java/com/spotify/docker/PushMojoTest.java
@@ -30,14 +30,22 @@ import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import java.io.File;
 
 import static com.googlecode.catchexception.CatchException.verifyException;
-import static com.spotify.docker.TestUtils.getPomAndAssertExists;
-import static org.mockito.Mockito.*;
-import static org.assertj.core.api.Assertions.*;
+import static com.spotify.docker.TestUtils.getPom;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 public class PushMojoTest extends AbstractMojoTestCase {
 
   public void testPush() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-push.xml");
+    final File pom = getPom("/pom-push.xml");
 
     final PushMojo mojo = (PushMojo) lookupMojo("push", pom);
     assertNotNull(mojo);
@@ -47,7 +55,7 @@ public class PushMojoTest extends AbstractMojoTestCase {
   }
 
   public void testFailingPushWithRetries() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-push.xml");
+    final File pom = getPom("/pom-push.xml");
 
     final PushMojo mojo = (PushMojo) lookupMojo("push", pom);
     assertNotNull(mojo);
@@ -60,7 +68,7 @@ public class PushMojoTest extends AbstractMojoTestCase {
   }
 
   public void testPushPrivateRepo() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-push-private-repo.xml");
+    final File pom = getPom("/pom-push-private-repo.xml");
 
     final PushMojo mojo = (PushMojo) lookupMojo("push", pom);
     assertNotNull(mojo);
@@ -80,7 +88,7 @@ public class PushMojoTest extends AbstractMojoTestCase {
   public void testPushSkipPush() throws Exception {
 
     final PushMojo mojo = (PushMojo) lookupMojo("push",
-        getPomAndAssertExists("/pom-push-skip-push.xml"));
+        getPom("/pom-push-skip-push.xml"));
     assertThat(mojo).isNotNull();
     assertThat(mojo.isSkipDockerPush()).isTrue();
 
@@ -93,7 +101,7 @@ public class PushMojoTest extends AbstractMojoTestCase {
 
   public void testPushSkipDocker() throws Exception {
     final PushMojo mojo = (PushMojo) lookupMojo("push",
-        getPomAndAssertExists("/pom-push-skip-docker.xml"));
+        getPom("/pom-push-skip-docker.xml"));
     assertThat(mojo).isNotNull();
     assertThat(mojo.isSkipDocker()).isTrue();
 

--- a/src/test/java/com/spotify/docker/PushMojoTest.java
+++ b/src/test/java/com/spotify/docker/PushMojoTest.java
@@ -30,19 +30,14 @@ import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import java.io.File;
 
 import static com.googlecode.catchexception.CatchException.verifyException;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static com.spotify.docker.TestUtils.getPomAndAssertExists;
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.*;
 
 public class PushMojoTest extends AbstractMojoTestCase {
 
   public void testPush() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-push.xml");
-    assertNotNull("Null pom.xml", pom);
-    assertTrue("pom.xml does not exist", pom.exists());
+    final File pom = getPomAndAssertExists("/pom-push.xml");
 
     final PushMojo mojo = (PushMojo) lookupMojo("push", pom);
     assertNotNull(mojo);
@@ -52,9 +47,7 @@ public class PushMojoTest extends AbstractMojoTestCase {
   }
 
   public void testFailingPushWithRetries() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-push.xml");
-    assertNotNull("Null pom.xml", pom);
-    assertTrue("pom.xml does not exist", pom.exists());
+    final File pom = getPomAndAssertExists("/pom-push.xml");
 
     final PushMojo mojo = (PushMojo) lookupMojo("push", pom);
     assertNotNull(mojo);
@@ -67,9 +60,7 @@ public class PushMojoTest extends AbstractMojoTestCase {
   }
 
   public void testPushPrivateRepo() throws Exception {
-    final File pom = getTestFile("src/test/resources/pom-push-private-repo.xml");
-    assertNotNull("Null pom.xml", pom);
-    assertTrue("pom.xml does not exist", pom.exists());
+    final File pom = getPomAndAssertExists("/pom-push-private-repo.xml");
 
     final PushMojo mojo = (PushMojo) lookupMojo("push", pom);
     assertNotNull(mojo);
@@ -83,6 +74,30 @@ public class PushMojoTest extends AbstractMojoTestCase {
 
     mojo.execute(docker);
     verify(docker).push(eq("dxia3/docker-maven-plugin-auth"), any(AnsiProgressHandler.class));
+  }
+
+  public void testPushSkipPush() throws Exception {
+
+    final PushMojo mojo = (PushMojo) lookupMojo("push", getPomAndAssertExists("/pom-push-skip-push.xml"));
+    assertThat(mojo).isNotNull();
+    assertThat(mojo.isSkipDockerPush()).isTrue();
+
+    final DockerClient docker = mock(DockerClient.class);
+    mojo.execute(docker);
+
+    verify(docker, never())
+        .push(anyString(), any(AnsiProgressHandler.class));
+  }
+
+  public void testPushSkipDocker() throws Exception {
+    final PushMojo mojo = (PushMojo) lookupMojo("push", getPomAndAssertExists("/pom-push-skip-docker.xml"));
+    assertThat(mojo).isNotNull();
+    assertThat(mojo.isSkipDocker()).isTrue();
+
+    PushMojo mojoSpy = spy(mojo);
+    mojo.execute();
+
+    verify(mojoSpy, never()).execute(any(DockerClient.class));
   }
 
 }

--- a/src/test/java/com/spotify/docker/TagMojoTest.java
+++ b/src/test/java/com/spotify/docker/TagMojoTest.java
@@ -75,7 +75,8 @@ public class TagMojoTest extends AbstractMojoTestCase {
   }
 
   public void testTagSkipTag() throws Exception {
-    final TagMojo mojo = (TagMojo) lookupMojo("tag", getPomAndAssertExists("/pom-tag-skip-tag.xml"));
+    final TagMojo mojo = (TagMojo) lookupMojo("tag",
+        getPomAndAssertExists("/pom-tag-skip-tag.xml"));
     assertThat(mojo).isNotNull();
     assertThat(mojo.isSkipDockerTag()).isTrue();
 
@@ -87,10 +88,11 @@ public class TagMojoTest extends AbstractMojoTestCase {
   }
 
   public void testTagSkipDocker() throws Exception {
-    final TagMojo mojo = (TagMojo) lookupMojo("tag", getPomAndAssertExists("/pom-tag-skip-docker.xml"));
+    final TagMojo mojo = (TagMojo) lookupMojo("tag",
+        getPomAndAssertExists("/pom-tag-skip-docker.xml"));
     assertThat(mojo.isSkipDocker()).isTrue();
 
-    TagMojo mojoSpy = spy(mojo);
+    final TagMojo mojoSpy = spy(mojo);
     mojo.execute();
 
     verify(mojoSpy, never()).execute(any(DockerClient.class));

--- a/src/test/java/com/spotify/docker/TagMojoTest.java
+++ b/src/test/java/com/spotify/docker/TagMojoTest.java
@@ -23,20 +23,26 @@ package com.spotify.docker;
 
 import com.spotify.docker.client.AnsiProgressHandler;
 import com.spotify.docker.client.DockerClient;
-
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.mockito.ArgumentCaptor;
 
 import java.io.File;
 
-import static com.spotify.docker.TestUtils.getPomAndAssertExists;
-import static org.mockito.Mockito.*;
-import static org.assertj.core.api.Assertions.*;
+import static com.spotify.docker.TestUtils.getPom;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 public class TagMojoTest extends AbstractMojoTestCase {
 
   public void testTag1() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-tag1.xml");
+    final File pom = getPom("/pom-tag1.xml");
 
     final TagMojo mojo = (TagMojo) lookupMojo("tag", pom);
     assertNotNull(mojo);
@@ -47,7 +53,7 @@ public class TagMojoTest extends AbstractMojoTestCase {
   }
 
   public void testTag2() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-tag2.xml");
+    final File pom = getPom("/pom-tag2.xml");
 
     final TagMojo mojo = (TagMojo) lookupMojo("tag", pom);
     assertNotNull(mojo);
@@ -65,7 +71,7 @@ public class TagMojoTest extends AbstractMojoTestCase {
   }
 
   public void testTag3() throws Exception {
-    final File pom = getPomAndAssertExists("/pom-tag3.xml");
+    final File pom = getPom("/pom-tag3.xml");
 
     final TagMojo mojo = (TagMojo) lookupMojo("tag", pom);
     assertNotNull(mojo);
@@ -76,7 +82,7 @@ public class TagMojoTest extends AbstractMojoTestCase {
 
   public void testTagSkipTag() throws Exception {
     final TagMojo mojo = (TagMojo) lookupMojo("tag",
-        getPomAndAssertExists("/pom-tag-skip-tag.xml"));
+        getPom("/pom-tag-skip-tag.xml"));
     assertThat(mojo).isNotNull();
     assertThat(mojo.isSkipDockerTag()).isTrue();
 
@@ -89,7 +95,7 @@ public class TagMojoTest extends AbstractMojoTestCase {
 
   public void testTagSkipDocker() throws Exception {
     final TagMojo mojo = (TagMojo) lookupMojo("tag",
-        getPomAndAssertExists("/pom-tag-skip-docker.xml"));
+        getPom("/pom-tag-skip-docker.xml"));
     assertThat(mojo.isSkipDocker()).isTrue();
 
     final TagMojo mojoSpy = spy(mojo);

--- a/src/test/java/com/spotify/docker/TestUtils.java
+++ b/src/test/java/com/spotify/docker/TestUtils.java
@@ -23,16 +23,13 @@ package com.spotify.docker;
 
 import java.io.File;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 public class TestUtils {
 
   private TestUtils() {
   }
 
-  public static File getPomAndAssertExists(String filename) throws Exception {
-    final File pom = new File(TestUtils.class.getResource(filename).toURI());
-    assertThat(pom).isNotNull().exists();
-    return pom;
+  public static File getPom(String filename) throws Exception {
+    return new File(TestUtils.class.getResource(filename).toURI());
   }
+
 }

--- a/src/test/java/com/spotify/docker/TestUtils.java
+++ b/src/test/java/com/spotify/docker/TestUtils.java
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2014 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.spotify.docker;
 
 import java.io.File;
@@ -10,7 +31,7 @@ public class TestUtils {
   }
 
   public static File getPomAndAssertExists(String filename) throws Exception {
-    File pom = new File(TestUtils.class.getResource(filename).toURI());
+    final File pom = new File(TestUtils.class.getResource(filename).toURI());
     assertThat(pom).isNotNull().exists();
     return pom;
   }

--- a/src/test/java/com/spotify/docker/TestUtils.java
+++ b/src/test/java/com/spotify/docker/TestUtils.java
@@ -1,0 +1,17 @@
+package com.spotify.docker;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestUtils {
+
+  private TestUtils() {
+  }
+
+  public static File getPomAndAssertExists(String filename) throws Exception {
+    File pom = new File(TestUtils.class.getResource(filename).toURI());
+    assertThat(pom).isNotNull().exists();
+    return pom;
+  }
+}

--- a/src/test/java/com/spotify/docker/UtilsTest.java
+++ b/src/test/java/com/spotify/docker/UtilsTest.java
@@ -86,7 +86,7 @@ public class UtilsTest {
     final DockerClient dockerClient = mock(DockerClient.class);
     final Log log = mock(Log.class);
     final DockerBuildInformation buildInfo = mock(DockerBuildInformation.class);
-    Utils.pushImage(dockerClient, IMAGE, log, buildInfo, 0, 1);
+    Utils.pushImage(dockerClient, IMAGE, log, buildInfo, 0, 1, false);
 
     verify(dockerClient).push(eq(IMAGE), any(AnsiProgressHandler.class));
   }

--- a/src/test/resources/pom-build-skip-build.xml
+++ b/src/test/resources/pom-build-skip-build.xml
@@ -17,16 +17,10 @@
                 <artifactId>docker-maven-plugin</artifactId>
                 <version>0.1-SNAPSHOT</version>
                 <configuration>
-                    <!-- we have to supply values for all params because unit testing framework -->
-                    <!-- doesn't set default values even though the are set in mojo-->
                     <dockerHost>http://host:2375</dockerHost>
                     <dockerDirectory>src/test/resources/dockerDirectory</dockerDirectory>
                     <imageName>busybox</imageName>
-                    <imageTags>
-                        <imageTag>latest</imageTag>
-                    </imageTags>
-                    <!-- test image tag is pushed -->
-                    <pushImageTag>true</pushImageTag>
+                    <skipDockerBuild>true</skipDockerBuild>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/test/resources/pom-build-skip-docker.xml
+++ b/src/test/resources/pom-build-skip-docker.xml
@@ -17,16 +17,10 @@
                 <artifactId>docker-maven-plugin</artifactId>
                 <version>0.1-SNAPSHOT</version>
                 <configuration>
-                    <!-- we have to supply values for all params because unit testing framework -->
-                    <!-- doesn't set default values even though the are set in mojo-->
                     <dockerHost>http://host:2375</dockerHost>
                     <dockerDirectory>src/test/resources/dockerDirectory</dockerDirectory>
                     <imageName>busybox</imageName>
-                    <imageTags>
-                        <imageTag>latest</imageTag>
-                    </imageTags>
-                    <!-- test image tag is pushed -->
-                    <pushImageTag>true</pushImageTag>
+                    <skipDocker>true</skipDocker>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/test/resources/pom-build-skip-push.xml
+++ b/src/test/resources/pom-build-skip-push.xml
@@ -17,16 +17,10 @@
                 <artifactId>docker-maven-plugin</artifactId>
                 <version>0.1-SNAPSHOT</version>
                 <configuration>
-                    <!-- we have to supply values for all params because unit testing framework -->
-                    <!-- doesn't set default values even though the are set in mojo-->
                     <dockerHost>http://host:2375</dockerHost>
                     <dockerDirectory>src/test/resources/dockerDirectory</dockerDirectory>
                     <imageName>busybox</imageName>
-                    <imageTags>
-                        <imageTag>latest</imageTag>
-                    </imageTags>
-                    <!-- test image tag is pushed -->
-                    <pushImageTag>true</pushImageTag>
+                    <skipDockerPush>true</skipDockerPush>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/test/resources/pom-push-skip-docker.xml
+++ b/src/test/resources/pom-push-skip-docker.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <name>Docker Maven Plugin Test Pom</name>
+  <groupId>com.spotify</groupId>
+  <artifactId>docker-maven-plugin-test</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <configuration>
+          <dockerHost>http://host:2375</dockerHost>
+          <imageName>busybox</imageName>
+          <retryPushTimeout>1</retryPushTimeout>
+          <retryPushCount>3</retryPushCount>
+          <skipDocker>true</skipDocker>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/pom-push-skip-push.xml
+++ b/src/test/resources/pom-push-skip-push.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <name>Docker Maven Plugin Test Pom</name>
+  <groupId>com.spotify</groupId>
+  <artifactId>docker-maven-plugin-test</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <configuration>
+          <dockerHost>http://host:2375</dockerHost>
+          <imageName>busybox</imageName>
+          <retryPushTimeout>1</retryPushTimeout>
+          <retryPushCount>3</retryPushCount>
+          <skipDockerPush>true</skipDockerPush>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/pom-tag-skip-docker.xml
+++ b/src/test/resources/pom-tag-skip-docker.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <name>Docker Maven Plugin Test Pom</name>
+  <groupId>com.spotify</groupId>
+  <artifactId>docker-maven-plugin-test</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <configuration>
+          <dockerHost>http://host:2375</dockerHost>
+          <image>imageToTag</image>
+          <newName>newRepo:newTag</newName>
+          <!-- test that useGitCommitId is ignored because tag is specified in imageName -->
+          <useGitCommitId>true</useGitCommitId>
+          <skipDocker>true</skipDocker>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources/pom-tag-skip-tag.xml
+++ b/src/test/resources/pom-tag-skip-tag.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <name>Docker Maven Plugin Test Pom</name>
+  <groupId>com.spotify</groupId>
+  <artifactId>docker-maven-plugin-test</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <configuration>
+          <dockerHost>http://host:2375</dockerHost>
+          <image>imageToTag</image>
+          <newName>newRepo:newTag</newName>
+          <!-- test that useGitCommitId is ignored because tag is specified in imageName -->
+          <useGitCommitId>true</useGitCommitId>
+          <skipDockerTag>true</skipDockerTag>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
Add
* `skipDocker` to skip any Docker goal (useful when goals are bound to maven phases)
* `skipDockerPush` to skip image push when `push` goal is bound to `deploy` phase

This PR is following https://github.com/spotify/docker-maven-plugin/issues/203