### PR TITLE
Push tags specified with imageTags

### DIFF
--- a/src/main/java/com/spotify/docker/PushMojo.java
+++ b/src/main/java/com/spotify/docker/PushMojo.java
@@ -53,7 +53,7 @@ public class PushMojo extends AbstractDockerMojo {
   protected void execute(DockerClient docker)
       throws MojoExecutionException, DockerException, IOException, InterruptedException {
     // Push specific tags specified in pom rather than all images
-    if (imageTags != null) {
+    if (imageTags != null && !imageTags.isEmpty()) {
       final String imageNameWithoutTag = parseImageName(imageName)[0];
       pushImageTag(docker, imageNameWithoutTag, imageTags, getLog());
     }

--- a/src/main/java/com/spotify/docker/PushMojo.java
+++ b/src/main/java/com/spotify/docker/PushMojo.java
@@ -29,8 +29,11 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.IOException;
+import java.util.List;
 
+import static com.spotify.docker.Utils.parseImageName;
 import static com.spotify.docker.Utils.pushImage;
+import static com.spotify.docker.Utils.pushImageTag;
 
 /**
  * Pushes a docker image repository to the specified docker registry.
@@ -42,8 +45,19 @@ public class PushMojo extends AbstractDockerMojo {
   @Parameter(property = "imageName", required = true)
   private String imageName;
 
+  /** Additional tags to tag the image with. */
+  @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
+  @Parameter(property = "dockerImageTags")
+  private List<String> imageTags;
+
   protected void execute(DockerClient docker)
       throws MojoExecutionException, DockerException, IOException, InterruptedException {
+    // Push specific tags specified in pom rather than all images
+    if (imageTags != null) {
+      final String imageNameWithoutTag = parseImageName(imageName)[0];
+      pushImageTag(docker, imageNameWithoutTag, imageTags, getLog());
+    }
+
     pushImage(docker, imageName, getLog(), null, getRetryPushCount(), getRetryPushTimeout());
   }
 

--- a/src/test/java/com/spotify/docker/PushMojoTest.java
+++ b/src/test/java/com/spotify/docker/PushMojoTest.java
@@ -66,6 +66,20 @@ public class PushMojoTest extends AbstractMojoTestCase {
     verify(docker, times(4)).push(eq("busybox"), any(AnsiProgressHandler.class));
   }
 
+  public void testPushTags() throws Exception {
+    final File pom = getTestFile("src/test/resources/pom-push-tags.xml");
+    assertNotNull("Null pom.xml", pom);
+    assertTrue("pom.xml does not exist", pom.exists());
+
+    final PushMojo mojo = (PushMojo) lookupMojo("push", pom);
+    assertNotNull(mojo);
+    final DockerClient docker = mock(DockerClient.class);
+    mojo.execute(docker);
+    verify(docker).push(eq("busybox:snapshot"), any(AnsiProgressHandler.class));
+    verify(docker).push(eq("busybox:0.0.1-SNAPSHOT"), any(AnsiProgressHandler.class));
+    verify(docker).push(eq("busybox"), any(AnsiProgressHandler.class));
+  }
+
   public void testPushPrivateRepo() throws Exception {
     final File pom = getTestFile("src/test/resources/pom-push-private-repo.xml");
     assertNotNull("Null pom.xml", pom);

--- a/src/test/resources/pom-push-tags.xml
+++ b/src/test/resources/pom-push-tags.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <name>Docker Maven Plugin Test Pom</name>
+  <groupId>com.spotify</groupId>
+  <artifactId>docker-maven-plugin-test</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <configuration>
+          <dockerHost>http://host:2375</dockerHost>
+          <imageName>busybox</imageName>
+          <imageTags>
+            <tag>snapshot</tag>
+            <tag>0.0.1-SNAPSHOT</tag>
+          </imageTags> 
+          <retryPushTimeout>1</retryPushTimeout>
+          <retryPushCount>3</retryPushCount>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
This PR is an conflict-less implementation of this PR #131.

I can now manage tags in a consistent way. On build the tags are applied on the local image and on push only the configured tags are pushed to the registry.   

```
<plugin>
    <groupId>com.spotify</groupId>
    <artifactId>docker-maven-plugin</artifactId>
    <configuration>
        <serverId>docker</serverId>
        <imageName>${docker.registry}/test-image</imageName>
        <imageTags>
            <tag>${parsedVersion.majorVersion}</tag>
            <tag>${parsedVersion.majourVersion}.${parsedVersion.buildNumber}</tag>
        </imageTags>
    </configuration>
    <executions>
        <execution>
            <id>build-image</id>
            <phase>compile</phase>
            <goals>
                <goal>build</goal>
            </goals>
        </execution>
        <execution>
            <id>push-tags</id>
            <phase>deploy</phase>
            <goals>
                <goal>push</goal>
            </goals>
       </execution>                        
    </executions>          
</plugin>
```
