### PR TITLE
Respect the tag specfied in the image name in removeImage

### DIFF
--- a/src/main/java/com/spotify/docker/RemoveImageMojo.java
+++ b/src/main/java/com/spotify/docker/RemoveImageMojo.java
@@ -32,7 +32,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -51,7 +51,7 @@ public class RemoveImageMojo extends AbstractDockerMojo {
   private String imageName;
 
   /**
-   * Additional tags to tag the image with.
+   * Additional tags to remove.
    */
   @Parameter(property = "dockerImageTags")
   private List<String> imageTags;
@@ -59,9 +59,10 @@ public class RemoveImageMojo extends AbstractDockerMojo {
   protected void execute(final DockerClient docker)
       throws MojoExecutionException, DockerException, IOException, InterruptedException {
     final String[] imageNameParts = parseImageName(imageName);
-    if (imageTags == null || imageTags.isEmpty()) {
-      imageTags = Collections.singletonList(imageNameParts[1]);
+    if (imageTags == null) {
+      imageTags = new ArrayList<>(1);
     }
+    imageTags.add(imageNameParts[1]);
 
     for (final String imageTag : imageTags) {
       final String currImageName = imageNameParts[0] +

--- a/src/main/java/com/spotify/docker/RemoveImageMojo.java
+++ b/src/main/java/com/spotify/docker/RemoveImageMojo.java
@@ -58,13 +58,13 @@ public class RemoveImageMojo extends AbstractDockerMojo {
 
   protected void execute(final DockerClient docker)
       throws MojoExecutionException, DockerException, IOException, InterruptedException {
-    final String imageNameWithoutTag = parseImageName(imageName)[0];
+    final String[] imageNameParts = parseImageName(imageName);
     if (imageTags == null) {
-      imageTags = Collections.singletonList("");
+      imageTags = Collections.singletonList(imageNameParts[1]);
     }
 
     for (final String imageTag : imageTags) {
-      final String currImageName = imageNameWithoutTag +
+      final String currImageName = imageNameParts[0] +
                              ((isNullOrEmpty(imageTag)) ? "" : (":" + imageTag));
       getLog().info("Removing -f " + currImageName);
 

--- a/src/main/java/com/spotify/docker/RemoveImageMojo.java
+++ b/src/main/java/com/spotify/docker/RemoveImageMojo.java
@@ -59,7 +59,7 @@ public class RemoveImageMojo extends AbstractDockerMojo {
   protected void execute(final DockerClient docker)
       throws MojoExecutionException, DockerException, IOException, InterruptedException {
     final String[] imageNameParts = parseImageName(imageName);
-    if (imageTags == null) {
+    if (imageTags == null || imageTags.isEmpty()) {
       imageTags = Collections.singletonList(imageNameParts[1]);
     }
 


### PR DESCRIPTION
PR #113 added support for multiple image tags for image removal, but that simple at a glance modification introduced a few problems:

1. If the name of the image contains a tag, it is ignored, and the operation will affect the :latest tag.
2. If there is no list of image tags specified, actually nothing will happen at all, because a list annotated with "@Parameter(property=...)" will be assigned an empty property and converted to an empty list. An empty list will result in no action due to (3).
3. If there is a list of image tags specified, they override the tag implied by the image name. This is inconsistent with docker:build, where additional tags really act as such, not as replacement.

(2) is not observable when running the tests, because the way plugins are configured is different for real projects. You can verify that by executing pom-removeImage.xml as standalone (mvn docker:removeImage -f pom-removeImage.xml, add -X to see how the configuration is resolved). I changed the plugin version to 0.4.8-SNAPSHOT and removed the dockerHost parameter to get it to run this way.

Each commit in this PR addresses one of the aforementioned issues.