### PR TITLE
Remove all tags

### DIFF
--- a/src/it/remove-all/pom.xml
+++ b/src/it/remove-all/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.spotify.docker.it</groupId>
+  <artifactId>remove-all</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <goals>
+              <goal>removeImage</goal>
+            </goals>
+            <phase>verify</phase>
+            <configuration>
+              <imageName>extra-tags</imageName>
+              <baseImage>java</baseImage>
+              <imageTags>
+                <tag>*</tag>
+              </imageTags>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/remove-all/pom.xml
+++ b/src/it/remove-all/pom.xml
@@ -29,9 +29,7 @@
             <configuration>
               <imageName>extra-tags</imageName>
               <baseImage>java</baseImage>
-              <imageTags>
-                <tag>*</tag>
-              </imageTags>
+              <removeAllTags>true</removeAllTags>
             </configuration>
           </execution>
         </executions>

--- a/src/main/java/com/spotify/docker/RemoveImageMojo.java
+++ b/src/main/java/com/spotify/docker/RemoveImageMojo.java
@@ -64,10 +64,10 @@ public class RemoveImageMojo extends AbstractDockerMojo {
       imageTags = Collections.singletonList("");
     } else if (imageTags.size() == 1 && imageTags.get(0).equals("*")) {
         // removal of all tags requested, loop over all images to find tags
-        for (Image currImage : docker.listImages()) {
+        for (final Image currImage : docker.listImages()) {
             getLog().debug("Found image: " + currImage.toString());
             String[] parsedRepoTag;
-            for (String repoTag : currImage.repoTags()) {
+            for (final String repoTag : currImage.repoTags()) {
                 parsedRepoTag = parseImageName(repoTag);
                 // if repo name matches imageName then save the tag for deletion
                 if (parsedRepoTag[0].equals(imageNameWithoutTag)) {

--- a/src/main/java/com/spotify/docker/RemoveImageMojo.java
+++ b/src/main/java/com/spotify/docker/RemoveImageMojo.java
@@ -57,12 +57,19 @@ public class RemoveImageMojo extends AbstractDockerMojo {
   @Parameter(property = "dockerImageTags")
   private List<String> imageTags;
 
+  /**
+   * Additional tags to tag the image with.
+   */
+  @Parameter(property = "removeAllTags", defaultValue = "false")
+  private boolean removeAllTags;
+
   protected void execute(final DockerClient docker)
       throws MojoExecutionException, DockerException, IOException, InterruptedException {
     final String imageNameWithoutTag = parseImageName(imageName)[0];
     if (imageTags == null) {
       imageTags = Collections.singletonList("");
-    } else if (imageTags.size() == 1 && imageTags.get(0).equals("*")) {
+    } else if (removeAllTags) {
+        getLog().info("Removal of all tags requested, searching for tags");
         // removal of all tags requested, loop over all images to find tags
         for (final Image currImage : docker.listImages()) {
             getLog().debug("Found image: " + currImage.toString());
@@ -76,8 +83,6 @@ public class RemoveImageMojo extends AbstractDockerMojo {
                 }
             }
         }
-        // '*' isn't a valid tag name so remove it from the list
-        imageTags.remove("*");
     }
 
     for (final String imageTag : imageTags) {


### PR DESCRIPTION
Related to issue #179. This adds support for specifying _-DremoveTags="*"_ to remove all tags of a given image, and includes an IT project. The primary use case for this is to run `mvn docker:removeImage -DdockerImageTags="*"` at the end of a CI build to ensure that an image which failed validation and thus wasn't published to the registry is not unwittingly exposed to subsequent builds on
