### PR TITLE
Make sure that you can apply multiple tags even if the imageName contains a tag

### DIFF
--- a/src/main/java/com/spotify/docker/CompositeImageName.java
+++ b/src/main/java/com/spotify/docker/CompositeImageName.java
@@ -53,11 +53,16 @@ class CompositeImageName {
       throw new MojoExecutionException("imageName not set!");
     }
 
-    final String tag = StringUtils.substringAfterLast(imageName, ":");
     final List<String> tags = new ArrayList<>();
-    tags.add(tag);
+    final String tag = StringUtils.substringAfterLast(imageName, ":");
+    if (StringUtils.isNotBlank(tag)) {
+      tags.add(tag);
+    }
     if (imageTags != null) {
       tags.addAll(imageTags);
+    }
+    if (tags.size() == 0) {
+      throw new MojoExecutionException("No tag included in imageName and no imageTags set!");
     }
     return new CompositeImageName(name, tags);
   }

--- a/src/main/java/com/spotify/docker/CompositeImageName.java
+++ b/src/main/java/com/spotify/docker/CompositeImageName.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.maven.plugin.MojoExecutionException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Container class for an image name and its desired tags.
+ */
+class CompositeImageName {
+
+  private final List<String> imageTags;
+  private final String name;
+
+  private CompositeImageName(final String name, final List<String> imageTags) {
+    this.name = name;
+    this.imageTags = imageTags;
+  }
+
+  /**
+   * An image name can be a plain image name or in the composite format &lt;name&gt;:&lt;tag&gt and
+   * this factory method makes sure that we get the plain image name as well as all the desired tags
+   * for an image, including any composite tag.
+   */
+  static CompositeImageName create(final String imageName, final List<String> imageTags)
+      throws MojoExecutionException {
+
+    final String name = StringUtils.substringBeforeLast(imageName, ":");
+    if (StringUtils.isBlank(name)) {
+      throw new MojoExecutionException("imageName not set!");
+    }
+
+    final String tag = StringUtils.substringAfterLast(imageName, ":");
+    final List<String> tags = new ArrayList<>();
+    tags.add(tag);
+    if (imageTags != null) {
+      tags.addAll(imageTags);
+    }
+    return new CompositeImageName(name, tags);
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public List<String> getImageTags() {
+    return imageTags;
+  }
+}

--- a/src/main/java/com/spotify/docker/Utils.java
+++ b/src/main/java/com/spotify/docker/Utils.java
@@ -115,13 +115,14 @@ public class Utils {
                                          + " not specified an \"imageTag\" in your"
                                          + " docker-maven-client's plugin configuration");
       }
-      for (final String imageTag : imageTags) {
-       final String imageNameWithTag = imageName + ":" + imageTag;
-       log.info("Pushing " + imageName + ":" + imageTag);
-       docker.push(imageNameWithTag, new AnsiProgressHandler());
-      }
+    final CompositeImageName compositeImageName = CompositeImageName.create(imageName, imageTags);
+    for (final String imageTag : compositeImageName.getImageTags()) {
+      final String imageNameWithTag = compositeImageName.getName() + ":" + imageTag;
+      log.info("Pushing " + imageNameWithTag);
+      docker.push(imageNameWithTag, new AnsiProgressHandler());
+    }
   }
-  
+
   public static void writeImageInfoFile(final DockerBuildInformation buildInfo,
                                         final String tagInfoFile) throws IOException {
     final Path imageInfoPath = Paths.get(tagInfoFile);

--- a/src/test/java/com/spotify/docker/BuildMojoTest.java
+++ b/src/test/java/com/spotify/docker/BuildMojoTest.java
@@ -359,6 +359,26 @@ public class BuildMojoTest extends AbstractMojoTestCase {
     verify(docker).push(eq("busybox:latest"), any(AnsiProgressHandler.class));
   }
 
+  public void testBuildWithMultiplePushTagButNoTagsSpecified() throws Exception {
+    final File pom = getTestFile("src/test/resources/pom-build-push-tags-no-tags-provided.xml");
+    assertNotNull("Null pom.xml", pom);
+    assertTrue("pom.xml does not exist", pom.exists());
+
+    final BuildMojo mojo = setupMojo(pom);
+    final DockerClient docker = mock(DockerClient.class);
+
+    try {
+      mojo.execute(docker);
+      fail("mojo should have thrown exception because imageTags are not defined in pom");
+    } catch (MojoExecutionException e) {
+      final String message = "You have used option \"pushImageTag\" but have"
+                             + " not specified an \"imageTag\" in your"
+                             + " docker-maven-client's plugin configuration";
+      assertTrue(String.format("Exception message should have contained '%s'", message),
+                 e.getMessage().contains(message));
+    }
+  }
+
   public void testBuildWithMultipleCompositePushTag() throws Exception {
     final File pom = getTestFile("src/test/resources/pom-build-push-tags-composite.xml");
     assertNotNull("Null pom.xml", pom);

--- a/src/test/java/com/spotify/docker/CompositeImageNameTest.java
+++ b/src/test/java/com/spotify/docker/CompositeImageNameTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2016 Spotify AB.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.spotify.docker;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
+
+public class CompositeImageNameTest {
+
+  @Test
+  public void testStandardCompositeNameWithoutImageTags() throws MojoExecutionException {
+    final CompositeImageName
+        compositeImageName = CompositeImageName.create("imageName:tagName", null);
+    assertEquals("imageName", compositeImageName.getName());
+    assertEquals("tagName", compositeImageName.getImageTags().get(0));
+  }
+
+  @Test
+  public void testStandardCompositeNameWithImageTags() throws MojoExecutionException {
+    final List<String> imageTags = Arrays.asList("tag1", "tag2");
+    final CompositeImageName
+        compositeImageName = CompositeImageName.create("imageName:tagName", imageTags);
+    assertEquals("imageName", compositeImageName.getName());
+    assertEquals("tagName", compositeImageName.getImageTags().get(0));
+    assertEquals("tag1", compositeImageName.getImageTags().get(1));
+    assertEquals("tag2", compositeImageName.getImageTags().get(2));
+  }
+
+  @Test
+  public void testCompositeNameWithoutTag() throws MojoExecutionException {
+    final CompositeImageName
+        compositeImageName = CompositeImageName.create("imageName", null);
+    assertEquals("imageName", compositeImageName.getName());
+    assertEquals(1, compositeImageName.getImageTags().size());
+    assertEquals("", compositeImageName.getImageTags().get(0));
+  }
+
+  @Test
+  public void testCompositeNameWithoutTagWithImageTags() throws MojoExecutionException {
+    final List<String> imageTags = Arrays.asList("tag1", "tag2");
+    final CompositeImageName
+        compositeImageName = CompositeImageName.create("imageName", imageTags);
+    assertEquals("imageName", compositeImageName.getName());
+    assertEquals(3, compositeImageName.getImageTags().size());
+    assertEquals("", compositeImageName.getImageTags().get(0));
+    assertEquals("tag1", compositeImageName.getImageTags().get(1));
+    assertEquals("tag2", compositeImageName.getImageTags().get(2));
+  }
+
+  @Test
+  public void testInvalidCompositeImageName() throws MojoExecutionException {
+    compositeImageNameExpectsException(null);
+    compositeImageNameExpectsException("");
+    compositeImageNameExpectsException(":tagname");
+  }
+
+  private void compositeImageNameExpectsException(final String imageName) {
+    try {
+      CompositeImageName.create(imageName, null);
+      fail("Should have thrown exception because ${imageName} is not defined");
+    } catch (MojoExecutionException ex) {
+      final String message = "imageName not set";
+      assertTrue(String.format("Exception message should have contained '%s'", message),
+                 ex.getMessage().contains(message));
+    }
+  }
+
+}

--- a/src/test/java/com/spotify/docker/CompositeImageNameTest.java
+++ b/src/test/java/com/spotify/docker/CompositeImageNameTest.java
@@ -24,6 +24,7 @@ package com.spotify.docker;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -53,39 +54,44 @@ public class CompositeImageNameTest {
   }
 
   @Test
-  public void testCompositeNameWithoutTag() throws MojoExecutionException {
-    final CompositeImageName
-        compositeImageName = CompositeImageName.create("imageName", null);
-    assertEquals("imageName", compositeImageName.getName());
-    assertEquals(1, compositeImageName.getImageTags().size());
-    assertEquals("", compositeImageName.getImageTags().get(0));
-  }
-
-  @Test
   public void testCompositeNameWithoutTagWithImageTags() throws MojoExecutionException {
     final List<String> imageTags = Arrays.asList("tag1", "tag2");
     final CompositeImageName
         compositeImageName = CompositeImageName.create("imageName", imageTags);
     assertEquals("imageName", compositeImageName.getName());
-    assertEquals(3, compositeImageName.getImageTags().size());
-    assertEquals("", compositeImageName.getImageTags().get(0));
-    assertEquals("tag1", compositeImageName.getImageTags().get(1));
-    assertEquals("tag2", compositeImageName.getImageTags().get(2));
+    assertEquals(2, compositeImageName.getImageTags().size());
+    assertEquals("tag1", compositeImageName.getImageTags().get(0));
+    assertEquals("tag2", compositeImageName.getImageTags().get(1));
   }
 
   @Test
-  public void testInvalidCompositeImageName() throws MojoExecutionException {
-    compositeImageNameExpectsException(null);
-    compositeImageNameExpectsException("");
-    compositeImageNameExpectsException(":tagname");
+  public void testInvalidCompositeImageNameAndTagCombinations() throws MojoExecutionException {
+    final String noImageNameErrorMessage = "imageName not set";
+    final String noImageTagsErrorMessage = "no imageTags set";
+    final List<String> emtpy = new ArrayList<>();
+    final List<String> tags = Arrays.asList("tag1", "tag2");
+
+    compositeImageNameExpectsException(noImageNameErrorMessage, null, null);
+    compositeImageNameExpectsException(noImageNameErrorMessage, null, emtpy);
+    compositeImageNameExpectsException(noImageNameErrorMessage, null, tags);
+    compositeImageNameExpectsException(noImageNameErrorMessage, "", null);
+    compositeImageNameExpectsException(noImageNameErrorMessage, "", emtpy);
+    compositeImageNameExpectsException(noImageNameErrorMessage, "", tags);
+    compositeImageNameExpectsException(noImageNameErrorMessage, ":tagname", null);
+    compositeImageNameExpectsException(noImageNameErrorMessage, ":tagname", emtpy);
+    compositeImageNameExpectsException(noImageNameErrorMessage, ":tagname", tags);
+
+    compositeImageNameExpectsException(noImageTagsErrorMessage, "imageName", null);
+    compositeImageNameExpectsException(noImageTagsErrorMessage, "imageName", emtpy);
   }
 
-  private void compositeImageNameExpectsException(final String imageName) {
+  private void compositeImageNameExpectsException(final String message,
+                                                  final String imageName,
+                                                  final List<String> imageTags) {
     try {
-      CompositeImageName.create(imageName, null);
+      CompositeImageName.create(imageName, imageTags);
       fail("Should have thrown exception because ${imageName} is not defined");
     } catch (MojoExecutionException ex) {
-      final String message = "imageName not set";
       assertTrue(String.format("Exception message should have contained '%s'", message),
                  ex.getMessage().contains(message));
     }

--- a/src/test/resources/pom-build-push-composite.xml
+++ b/src/test/resources/pom-build-push-composite.xml
@@ -21,14 +21,9 @@
                     <!-- doesn't set default values even though the are set in mojo-->
                     <dockerHost>http://host:2375</dockerHost>
                     <dockerDirectory>src/test/resources/dockerDirectory</dockerDirectory>
-                    <imageName>busybox</imageName>
-                    <imageTags>
-                        <imageTag>late</imageTag>
-                        <imageTag>later</imageTag>
-                        <imageTag>latest</imageTag>
-                    </imageTags>
-                    <!-- test image tag is pushed -->
-                    <pushImageTag>true</pushImageTag>
+                    <imageName>busybox:compositeNameTag</imageName>
+                    <!-- test image is pushed -->
+                    <pushImage>true</pushImage>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/test/resources/pom-build-push-tags-composite.xml
+++ b/src/test/resources/pom-build-push-tags-composite.xml
@@ -21,7 +21,7 @@
                     <!-- doesn't set default values even though the are set in mojo-->
                     <dockerHost>http://host:2375</dockerHost>
                     <dockerDirectory>src/test/resources/dockerDirectory</dockerDirectory>
-                    <imageName>busybox</imageName>
+                    <imageName>busybox:compositeTag</imageName>
                     <imageTags>
                         <imageTag>late</imageTag>
                         <imageTag>later</imageTag>

--- a/src/test/resources/pom-build-push-tags-no-tags-provided.xml
+++ b/src/test/resources/pom-build-push-tags-no-tags-provided.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>Docker Maven Plugin Test Pom</name>
+    <groupId>com.spotify</groupId>
+    <artifactId>docker-maven-plugin-test</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.1-SNAPSHOT</version>
+                <configuration>
+                    <!-- we have to supply values for all params because unit testing framework -->
+                    <!-- doesn't set default values even though the are set in mojo-->
+                    <dockerHost>http://host:2375</dockerHost>
+                    <dockerDirectory>src/test/resources/dockerDirectory</dockerDirectory>
+                    <imageName>busybox</imageName>
+                    <imageTags>
+                    </imageTags>
+                    <!-- test image tag is pushed -->
+                    <pushImageTag>true</pushImageTag>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
I had the need to apply more than one tag to a docker image and that only worked when the `imageName` was in the format where it did **not** have a `:` in it. But then Helios would not deploy the new build. Helios needs a "composite image name" to deploy stuff.

The text in the `imageName` is currently the `name:tag` that Helios is using when deploying and I wanted to preserve the functionality that Helios is depending on so I have not, at least not knowingly, changed what gets written to the `image_info.json` file but only targeted the `pushImageTag` method of the `Utils` class.

This means that when you are using the `imageName` format that Helios is relying on you still get the same `image` attribute in `image_info.json`.