### PR TITLE
Issue #253: Creates target directory if doesn't already exist.

### DIFF
--- a/src/main/java/com/spotify/docker/BuildMojo.java
+++ b/src/main/java/com/spotify/docker/BuildMojo.java
@@ -712,11 +712,12 @@ public class BuildMojo extends AbstractDockerMojo {
 
     for (final Resource resource : resources) {
       final File source = new File(resource.getDirectory());
-      Files.createDirectories(source.toPath());
+      if (!source.exists()) {
+        Files.createDirectories(source.toPath());
+      }
       final List<String> includes = resource.getIncludes();
       final List<String> excludes = resource.getExcludes();
       final DirectoryScanner scanner = new DirectoryScanner();
-      
       scanner.setBasedir(source);
       // must pass null if includes/excludes is empty to get default filters.
       // passing zero length array forces it to have no filters at all.

--- a/src/main/java/com/spotify/docker/BuildMojo.java
+++ b/src/main/java/com/spotify/docker/BuildMojo.java
@@ -712,9 +712,11 @@ public class BuildMojo extends AbstractDockerMojo {
 
     for (final Resource resource : resources) {
       final File source = new File(resource.getDirectory());
+      Files.createDirectories(source.toPath());
       final List<String> includes = resource.getIncludes();
       final List<String> excludes = resource.getExcludes();
       final DirectoryScanner scanner = new DirectoryScanner();
+      
       scanner.setBasedir(source);
       // must pass null if includes/excludes is empty to get default filters.
       // passing zero length array forces it to have no filters at all.


### PR DESCRIPTION
This fixes an uncaught exception in the docker-maven-plugin where if the maven build does not produce a target directory before running the plugin, it will throw an uncaught exception and fail.

Fixes Issue #253.