### PR TITLE
Add ability to send --rm param on build (seems needed for CircleCI)

### DIFF
--- a/src/main/java/com/spotify/docker/BuildMojo.java
+++ b/src/main/java/com/spotify/docker/BuildMojo.java
@@ -127,6 +127,10 @@ public class BuildMojo extends AbstractDockerMojo {
   @Parameter(property = "noCache", defaultValue = "false")
   private boolean noCache;
 
+  /** Set to false to pass the `--rm` flag to the Docker daemon when building an image. */
+  @Parameter(property = "rm", defaultValue = "true")
+  private boolean rm;
+
   /** Flag to push image after it is built. Defaults to false. */
   @Parameter(property = "pushImage", defaultValue = "false")
   private boolean pushImage;
@@ -799,6 +803,9 @@ public class BuildMojo extends AbstractDockerMojo {
     if (noCache) {
       buildParams.add(DockerClient.BuildParam.noCache());
     }
+    if (!rm) {
+        buildParams.add(DockerClient.BuildParam.rm(false));
+      }
     if (!buildArgs.isEmpty()) {
       buildParams.add(DockerClient.BuildParam.create("buildargs", 
         URLEncoder.encode(OBJECT_MAPPER.writeValueAsString(buildArgs), "UTF-8")));

--- a/src/test/java/com/spotify/docker/BuildMojoTest.java
+++ b/src/test/java/com/spotify/docker/BuildMojoTest.java
@@ -527,6 +527,18 @@ public class BuildMojoTest extends AbstractMojoTestCase {
         eq(BuildParam.noCache()));
   }
 
+  public void testRmFalse() throws Exception {
+    final BuildMojo mojo = setupMojo(getPom("/pom-build-rm-false.xml"));
+    final DockerClient docker = mock(DockerClient.class);
+
+    mojo.execute(docker);
+
+    verify(docker).build(any(Path.class),
+        anyString(),
+        any(ProgressHandler.class),
+        eq(BuildParam.rm(false)));
+  }
+
   public void testBuildWithSkipDockerBuild() throws Exception {
     final BuildMojo mojo = setupMojo(getPom("/pom-build-skip-build.xml"));
     assertThat(mojo.isSkipDockerBuild()).isTrue();

--- a/src/test/resources/pom-build-rm-false.xml
+++ b/src/test/resources/pom-build-rm-false.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>Docker Maven Plugin Test Pom</name>
+    <groupId>com.spotify</groupId>
+    <artifactId>docker-maven-plugin-test</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>0.1-SNAPSHOT</version>
+                <configuration>
+                    <dockerHost>http://host:2375</dockerHost>
+                    <dockerDirectory>src/test/resources/dockerDirectory</dockerDirectory>
+                    <imageName>busybox</imageName>
+
+                    <rm>false</rm>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
This ability to de-activate the removal of intermediate images seems to be needed as a work-around for CircleCI: https://discuss.circleci.com/t/docker-error-removing-intermediate-container/70/24