### PR TITLE
useConfigFile now used as fall-back if settings exists, but server is…

### DIFF
--- a/src/main/java/com/spotify/docker/AbstractDockerMojo.java
+++ b/src/main/java/com/spotify/docker/AbstractDockerMojo.java
@@ -275,24 +275,26 @@ abstract class AbstractDockerMojo extends AbstractMojo {
         }
 
         return authConfigBuilder.build();
-      } else if (useConfigFile != null && useConfigFile){
-
-          final AuthConfig.Builder authConfigBuilder;
-          try {
-            if (!isNullOrEmpty(registryUrl)) {
-              authConfigBuilder = AuthConfig.fromDockerConfig(registryUrl);
-            } else {
-              authConfigBuilder = AuthConfig.fromDockerConfig();
-            }
-          } catch (IOException ex){
-            throw new MojoExecutionException(
-                      "Docker config file could not be read",
-                      ex
-            );
-          }
-
-          return authConfigBuilder.build();
       }
+    }
+
+    // use config file as last-effort fallback
+    if (useConfigFile != null && useConfigFile){
+      final AuthConfig.Builder authConfigBuilder;
+      try {
+        if (!isNullOrEmpty(registryUrl)) {
+          authConfigBuilder = AuthConfig.fromDockerConfig(registryUrl);
+        } else {
+          authConfigBuilder = AuthConfig.fromDockerConfig();
+        }
+      } catch (IOException ex){
+        throw new MojoExecutionException(
+                  "Docker config file could not be read",
+                  ex
+        );
+      }
+
+      return authConfigBuilder.build();
     }
     return null;
   }


### PR DESCRIPTION
If a `settings.xml` file is found, but no appropriate `<server>` is found, the `useConfigFile` parameter was skipped.

This request allows the check for `useConfigFile` to be used as a "last-ditch" for authentication.
