### PR TITLE
Added Docker 1.12 optional 'healthcheck' element.

### DIFF
--- a/src/main/java/com/spotify/docker/BuildMojo.java
+++ b/src/main/java/com/spotify/docker/BuildMojo.java
@@ -249,6 +249,12 @@ public class BuildMojo extends AbstractDockerMojo {
   @Parameter(property = "dockerBuildArgs")
   private Map<String, String> buildArgs;  
   
+  /** HEALTHCHECK. It expects a element for 'options' and 'cmd' 
+   * Added in docker 1.12 (https://docs.docker.com/engine/reference/builder/#/healthcheck). 
+   */
+  @Parameter(property = "healthcheck")
+  private Map<String, String> healthcheck;
+
   private PluginParameterExpressionEvaluator expressionEvaluator;
 
   public BuildMojo() {
@@ -620,6 +626,17 @@ public class BuildMojo extends AbstractDockerMojo {
           commands.add("RUN " + run);
         }
       }
+    }
+
+    if (healthcheck != null && healthcheck.containsKey("cmd")) {
+      final StringBuffer healthcheckBuffer = new StringBuffer("HEALTHCHECK ");
+      if (healthcheck.containsKey("options")) {
+        healthcheckBuffer.append(healthcheck.get("options"));
+        healthcheckBuffer.append(" ");
+      }
+      healthcheckBuffer.append("CMD ");
+      healthcheckBuffer.append(healthcheck.get("cmd"));
+      commands.add(healthcheckBuffer.toString());
     }
 
     if (exposesSet.size() > 0) {

--- a/src/test/java/com/spotify/docker/BuildMojoTest.java
+++ b/src/test/java/com/spotify/docker/BuildMojoTest.java
@@ -78,6 +78,7 @@ public class BuildMojoTest extends AbstractMojoTestCase {
       "ADD copy2.json .",
       "RUN ln -s /a /b",
       "RUN wget 127.0.0.1:8080",
+      "HEALTHCHECK --interval=30s CMD curl --fail http://localhost:8080/ || exit 1",
       "EXPOSE 8080 8081",
       "USER app",
       "ENTRYPOINT date",

--- a/src/test/resources/pom-build-generated-dockerfile.xml
+++ b/src/test/resources/pom-build-generated-dockerfile.xml
@@ -26,6 +26,10 @@
           <env>
             <FOO>BAR</FOO>
           </env>
+          <healthcheck> 
+            <options>--interval=30s</options>
+          	<cmd>curl --fail http://localhost:8080/ || exit 1</cmd>
+          </healthcheck>
           <exposes>
             <expose>8081</expose>
             <expose>8080</expose>


### PR DESCRIPTION
Hello,

The pull request is to add in an element for the new docker 1.12 healthcheck functionality (https://docs.docker.com/engine/reference/builder/#/healthcheck).

Cheers,

Ron