### PR TITLE
Add support for image names with private registry and port

### DIFF
--- a/src/main/java/com/spotify/docker/CompositeImageName.java
+++ b/src/main/java/com/spotify/docker/CompositeImageName.java
@@ -48,13 +48,15 @@ class CompositeImageName {
   static CompositeImageName create(final String imageName, final List<String> imageTags)
       throws MojoExecutionException {
 
-    final String name = StringUtils.substringBeforeLast(imageName, ":");
+    final boolean containsTag = containsTag(imageName);
+
+    final String name = containsTag ? StringUtils.substringBeforeLast(imageName, ":") : imageName;
     if (StringUtils.isBlank(name)) {
       throw new MojoExecutionException("imageName not set!");
     }
 
     final List<String> tags = new ArrayList<>();
-    final String tag = StringUtils.substringAfterLast(imageName, ":");
+    final String tag = containsTag ? StringUtils.substringAfterLast(imageName, ":") : "";
     if (StringUtils.isNotBlank(tag)) {
       tags.add(tag);
     }
@@ -73,5 +75,20 @@ class CompositeImageName {
 
   public List<String> getImageTags() {
     return imageTags;
+  }
+
+  static boolean containsTag(String imageName) {
+    if (StringUtils.contains(imageName, ":")) {
+      if (StringUtils.contains(imageName, "/")) {
+        final String registryPart = StringUtils.substringBeforeLast(imageName, "/");
+        final String imageNamePart = StringUtils.substring(imageName, registryPart.length() + 1);
+
+        return StringUtils.contains(imageNamePart, ":");
+      } else {
+        return true;
+      }
+    }
+
+    return false;
   }
 }

--- a/src/test/java/com/spotify/docker/CompositeImageNameTest.java
+++ b/src/test/java/com/spotify/docker/CompositeImageNameTest.java
@@ -26,8 +26,10 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.*;
@@ -65,6 +67,31 @@ public class CompositeImageNameTest {
   }
 
   @Test
+  public void testImageWithRegistryHostnameAndPortWithoutTag() throws MojoExecutionException {
+    final List<String> imageTags = Collections.singletonList("tag1");
+    final String imageNameWithRegistry = "registry:8888/imageName";
+    final CompositeImageName
+            compositeImageName = CompositeImageName.create(imageNameWithRegistry, imageTags);
+
+    assertEquals(imageNameWithRegistry, compositeImageName.getName());
+    assertEquals(1, compositeImageName.getImageTags().size());
+    assertEquals("tag1", compositeImageName.getImageTags().get(0));
+  }
+
+  @Test
+  public void testImageWithRegistryHostnameAndPortWithTag() throws MojoExecutionException {
+    final List<String> imageTags = Collections.singletonList("tag2");
+    final String imageNameWithRegistryAndTag = "registry:8888/imageName:tag1";
+    final CompositeImageName
+            compositeImageName = CompositeImageName.create(imageNameWithRegistryAndTag, imageTags);
+
+    assertEquals("registry:8888/imageName", compositeImageName.getName());
+    assertEquals(2, compositeImageName.getImageTags().size());
+    assertEquals("tag1", compositeImageName.getImageTags().get(0));
+    assertEquals("tag2", compositeImageName.getImageTags().get(1));
+  }
+
+  @Test
   public void testInvalidCompositeImageNameAndTagCombinations() throws MojoExecutionException {
     final String noImageNameErrorMessage = "imageName not set";
     final String noImageTagsErrorMessage = "no imageTags set";
@@ -83,6 +110,17 @@ public class CompositeImageNameTest {
 
     compositeImageNameExpectsException(noImageTagsErrorMessage, "imageName", null);
     compositeImageNameExpectsException(noImageTagsErrorMessage, "imageName", emtpy);
+  }
+
+  @Test
+  public void testContainsTag() {
+    assertTrue(CompositeImageName.containsTag("imageName:tag"));
+    assertTrue(CompositeImageName.containsTag("registry/imageName:tag"));
+    assertTrue(CompositeImageName.containsTag("registry:8888/imageName:tag"));
+
+    assertFalse(CompositeImageName.containsTag("imageName"));
+    assertFalse(CompositeImageName.containsTag("registry/imageName"));
+    assertFalse(CompositeImageName.containsTag("registry:8888/imageName"));
   }
 
   private void compositeImageNameExpectsException(final String message,


### PR DESCRIPTION
Pull request for https://github.com/spotify/docker-maven-plugin/issues/319

Adds support for image names with private registry and port, only taking the `:`character as a separator, if it occurs after the registry part, or if no registry part is provided.