### PR TITLE
Add option to the build mojo which allows 'docker save' on image

### DIFF
--- a/src/main/java/com/spotify/docker/BuildMojo.java
+++ b/src/main/java/com/spotify/docker/BuildMojo.java
@@ -75,6 +75,7 @@ import static com.google.common.collect.Ordering.natural;
 import static com.spotify.docker.Utils.parseImageName;
 import static com.spotify.docker.Utils.pushImage;
 import static com.spotify.docker.Utils.pushImageTag;
+import static com.spotify.docker.Utils.saveImage;
 import static com.spotify.docker.Utils.writeImageInfoFile;
 import static com.typesafe.config.ConfigRenderOptions.concise;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -130,6 +131,10 @@ public class BuildMojo extends AbstractDockerMojo {
   /** Set to false to pass the `--rm` flag to the Docker daemon when building an image. */
   @Parameter(property = "rm", defaultValue = "true")
   private boolean rm;
+
+  /** File path to save image as a tar archive after it is built. */
+  @Parameter(property = "saveImageToTarArchive")
+  private String saveImageToTarArchive;
 
   /** Flag to push image after it is built. Defaults to false. */
   @Parameter(property = "pushImage", defaultValue = "false")
@@ -370,6 +375,10 @@ public class BuildMojo extends AbstractDockerMojo {
     if (pushImage) {
       pushImage(docker, imageName, getLog(), buildInfo, getRetryPushCount(), getRetryPushTimeout(),
           isSkipDockerPush());
+    }
+
+    if (saveImageToTarArchive != null) {
+        saveImage(docker, imageName, Paths.get(saveImageToTarArchive), getLog());
     }
 
     // Write image info file

--- a/src/main/java/com/spotify/docker/Utils.java
+++ b/src/main/java/com/spotify/docker/Utils.java
@@ -30,10 +30,12 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.Thread.sleep;
@@ -132,6 +134,15 @@ public class Utils {
       log.info("Pushing " + imageNameWithTag);
       docker.push(imageNameWithTag, new AnsiProgressHandler());
     }
+  }
+
+  public static void saveImage(DockerClient docker, String imageName,
+                                Path tarArchivePath, Log log)
+          throws DockerException, IOException, InterruptedException {
+      log.info(String.format("Save docker image %s to %s.",
+              imageName, tarArchivePath.toAbsolutePath()));
+      final InputStream is = docker.save(imageName);
+      java.nio.file.Files.copy(is, tarArchivePath, StandardCopyOption.REPLACE_EXISTING);
   }
 
   public static void writeImageInfoFile(final DockerBuildInformation buildInfo,

--- a/src/test/java/com/spotify/docker/UtilsTest.java
+++ b/src/test/java/com/spotify/docker/UtilsTest.java
@@ -24,8 +24,6 @@ package com.spotify.docker;
 import com.spotify.docker.client.AnsiProgressHandler;
 import com.spotify.docker.client.DockerClient;
 
-import junit.framework.Assert;
-
 import org.apache.commons.io.input.ReaderInputStream;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
@@ -39,16 +37,11 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.InputStream;
-import java.io.StringBufferInputStream;
 import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 public class UtilsTest {
 

--- a/src/test/java/com/spotify/docker/UtilsTest.java
+++ b/src/test/java/com/spotify/docker/UtilsTest.java
@@ -23,15 +23,32 @@ package com.spotify.docker;
 
 import com.spotify.docker.client.AnsiProgressHandler;
 import com.spotify.docker.client.DockerClient;
+
+import junit.framework.Assert;
+
+import org.apache.commons.io.input.ReaderInputStream;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.InputStream;
+import java.io.StringBufferInputStream;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class UtilsTest {
 
@@ -89,5 +106,29 @@ public class UtilsTest {
     Utils.pushImage(dockerClient, IMAGE, log, buildInfo, 0, 1, false);
 
     verify(dockerClient).push(eq(IMAGE), any(AnsiProgressHandler.class));
+  }
+
+  @Test
+  public void testSaveImage() throws Exception {
+    final DockerClient dockerClient = mock(DockerClient.class);
+    final Log log = mock(Log.class);
+    final Path path = Files.createTempFile(IMAGE, ".tgz");
+    final String imageDataLine = "TestDataForDockerImage";
+
+    Mockito.doAnswer(new Answer<InputStream>() {
+        @Override
+        public InputStream answer(InvocationOnMock invocation) throws Throwable {
+            return new ReaderInputStream(new StringReader(imageDataLine));
+        }
+    }).when(dockerClient).save(IMAGE);
+
+    try {
+        Utils.saveImage(dockerClient, IMAGE, path, log);
+        verify(dockerClient).save(eq(IMAGE));
+    } finally {
+        if (Files.exists(path)) {
+            Files.delete(path);
+        }
+    }
   }
 }


### PR DESCRIPTION
In addition to 'imagePush' sometimes it is useful to be able to save the image to tar archive. This pull request adds one more option to the configuration of the 'build' maven goal which allows an image to be saved as a tar archive. The option is called 'saveImageToTarArchive'.