### PR TITLE
Add short reference to an alternate docker-maven-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,13 @@ README.
 We are still happy to review new contributions to `docker-maven-plugin`, but we
 do not plan on making major new contributions ourselves in the future.
 
+Alternatively, if you still require a fully supported docker-maven-plugin with support 
+for building Docker images (also based on Dockerfiles) and running Docker 
+containers for integration tests, you might want to have a look at 
+[fabric8io/docker-maven-plugin][], too. 
+
 [dockerfile-maven]: https://github.com/spotify/dockerfile-maven
+[fabric8io/docker-maven-plugin]: https://github.com/fabric8io/docker-maven-plugin
 
 ## Purpose
 


### PR DESCRIPTION
Although dockerfile-maven provides a simplistic approach to Docker image build integration which does not carry the mental overhead of a full blown docker-maven-plugin, users of spotify/docker-maven-plugin might be still interested in keeping a more tight integration into Maven.

This PR adds a reference to the [fabric8io/docker-maven-plugin](https://github.com/fabric8io/docker-maven-plugin) which could be considered also as an alternative to this plugin (and provides some more features like running containers, but that is not the point). It's well maintained and comes with comprehensive [documentation](https://dmp.fabric8.io/).

WARNING: Of course I'm biased as I'm one of the main authors of this fabric8io/docker-maven-plugin. It's not about fishing for users or adding plugs, but I though it would be nice for your users to let them know that they have a choice.  

I always liked your plugin and the (mini) competition which also leads to quite some inspirations (and also some sort of ["shootout" comparisation](https://github.com/fabric8io/shootout-docker-maven). In all of my talks, I always mentioned spotify/docker-maven-plugin as a good alternative which provided Docker integration with a different twist (if you don't need to _run_ containers).

