### PR TITLE
Fix error when exporting image tar file

### DIFF
--- a/src/main/java/com/spotify/docker/Utils.java
+++ b/src/main/java/com/spotify/docker/Utils.java
@@ -141,8 +141,19 @@ public class Utils {
           throws DockerException, IOException, InterruptedException {
       log.info(String.format("Save docker image %s to %s.",
               imageName, tarArchivePath.toAbsolutePath()));
+      final Path archiveParentDir = tarArchivePath.getParent().toAbsolutePath();
+      if (Files.exists(archiveParentDir)) {
+         if (!Files.isDirectory(archiveParentDir)) {
+            throw new IOException(
+                  "The provided path for docker image tar archive export exists, "
+                        + "but is not a directory: " + archiveParentDir.toString());
+         }
+      } else {
+         Files.createDirectories(archiveParentDir);
+      }
       final InputStream is = docker.save(imageName);
-      java.nio.file.Files.copy(is, tarArchivePath, StandardCopyOption.REPLACE_EXISTING);
+      java.nio.file.Files.copy(is, tarArchivePath.toAbsolutePath(),
+            StandardCopyOption.REPLACE_EXISTING);
   }
 
   public static void writeImageInfoFile(final DockerBuildInformation buildInfo,


### PR DESCRIPTION
When the targeted path of an image tar file export contains non existent
directories the build fails. This change tries to create the required
directories if it has the permissions.
It will also throw more relevant exception if the parent dir of the
provided tar path exists but is not a directory.