### PR TITLE
Update docker-client to 8.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
-      <version>8.7.1</version>
+      <version>8.9.2</version>
       <classifier>shaded</classifier>
     </dependency>
     <dependency>


### PR DESCRIPTION
The docker-client release of 8.9.2 bumps jnr-unixsocket to 0.18 which supports ARM64.