### PR TITLE
Use docker-client 8.11.2 for wincred credStore support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 language: java
 
 jdk:
-  - oraclejdk7
+  - oraclejdk8
 
 env:
   global:

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
-      <version>8.7.1</version>
+      <version>8.11.3</version>
       <classifier>shaded</classifier>
     </dependency>
     <dependency>

--- a/src/main/java/com/spotify/docker/AbstractDockerMojo.java
+++ b/src/main/java/com/spotify/docker/AbstractDockerMojo.java
@@ -25,7 +25,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.base.Function;
-import com.google.common.base.Optional;
+import com.spotify.docker.client.shaded.com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.spotify.docker.client.DefaultDockerClient;
@@ -34,7 +34,7 @@ import com.spotify.docker.client.DockerCertificatesStore;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.auth.ConfigFileRegistryAuthSupplier;
 import com.spotify.docker.client.auth.MultiRegistryAuthSupplier;
-import com.spotify.docker.client.auth.NoOpRegistryAuthSupplier;
+import com.spotify.docker.client.auth.FixedRegistryAuthSupplier;
 import com.spotify.docker.client.auth.RegistryAuthSupplier;
 import com.spotify.docker.client.auth.gcr.ContainerRegistryAuthSupplier;
 import com.spotify.docker.client.exceptions.DockerCertificateException;
@@ -293,7 +293,7 @@ abstract class AbstractDockerMojo extends AbstractMojo {
       final RegistryConfigs configsForBuild = RegistryConfigs.create(ImmutableMap.of(
           serverIdFor(registryAuth), registryAuth
       ));
-      suppliers.add(new NoOpRegistryAuthSupplier(registryAuth, configsForBuild));
+      suppliers.add(new FixedRegistryAuthSupplier(registryAuth, configsForBuild));
     }
 
     getLog().info("Using authentication suppliers: " +

--- a/src/main/java/com/spotify/docker/AbstractDockerMojo.java
+++ b/src/main/java/com/spotify/docker/AbstractDockerMojo.java
@@ -25,7 +25,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.base.Function;
-import com.spotify.docker.client.shaded.com.google.common.base.Optional;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.spotify.docker.client.DefaultDockerClient;
@@ -33,8 +33,8 @@ import com.spotify.docker.client.DockerCertificates;
 import com.spotify.docker.client.DockerCertificatesStore;
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.auth.ConfigFileRegistryAuthSupplier;
-import com.spotify.docker.client.auth.MultiRegistryAuthSupplier;
 import com.spotify.docker.client.auth.FixedRegistryAuthSupplier;
+import com.spotify.docker.client.auth.MultiRegistryAuthSupplier;
 import com.spotify.docker.client.auth.RegistryAuthSupplier;
 import com.spotify.docker.client.auth.gcr.ContainerRegistryAuthSupplier;
 import com.spotify.docker.client.exceptions.DockerCertificateException;


### PR DESCRIPTION
credStore support was added to the docker-client in v8.11.2: https://github.com/spotify/docker-client/pull/945