### PR TITLE
Mark BuildMojo as threadSafe

### DIFF
--- a/src/main/java/com/spotify/docker/BuildMojo.java
+++ b/src/main/java/com/spotify/docker/BuildMojo.java
@@ -86,7 +86,7 @@ import static java.util.Collections.emptyList;
 /**
  * Used to build docker images.
  */
-@Mojo(name = "build")
+@Mojo(name = "build", threadSafe = true)
 public class BuildMojo extends AbstractDockerMojo {
 
   private static final Lock LOCK = new ReentrantLock();


### PR DESCRIPTION
Made thread safe in https://github.com/spotify/docker-maven-plugin/pull/383.
This annotation will remove a maven build warning.

Fixes #352