### PR TITLE
Remove all tags

### DIFF
--- a/src/it/remove-all/pom.xml
+++ b/src/it/remove-all/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.spotify.docker.it</groupId>
+  <artifactId>remove-all</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>@project.groupId@</groupId>
+        <artifactId>@project.artifactId@</artifactId>
+        <version>@project.version@</version>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <goals>
+              <goal>removeImage</goal>
+            </goals>
+            <phase>verify</phase>
+            <configuration>
+              <imageName>extra-tags</imageName>
+              <baseImage>java</baseImage>
+              <imageTags>
+                <tag>*</tag>
+              </imageTags>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/remove-all/pom.xml
+++ b/src/it/remove-all/pom.xml
@@ -29,9 +29,7 @@
             <configuration>
               <imageName>extra-tags</imageName>
               <baseImage>java</baseImage>
-              <imageTags>
-                <tag>*</tag>
-              </imageTags>
+              <removeAllTags>true</removeAllTags>
             </configuration>
           </execution>
         </executions>

--- a/src/main/java/com/spotify/docker/RemoveImageMojo.java
+++ b/src/main/java/com/spotify/docker/RemoveImageMojo.java
@@ -21,24 +21,21 @@
 
 package com.spotify.docker;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.spotify.docker.Utils.parseImageName;
+
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.exceptions.DockerException;
 import com.spotify.docker.client.exceptions.ImageNotFoundException;
 import com.spotify.docker.client.messages.Image;
 import com.spotify.docker.client.messages.RemovedImage;
 import com.spotify.docker.client.shaded.javax.ws.rs.NotFoundException;
-
-import java.util.Collections;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-
-import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.spotify.docker.Utils.parseImageName;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Removes a docker image.
@@ -66,31 +63,32 @@ public class RemoveImageMojo extends AbstractDockerMojo {
 
   @Override
   protected void execute(final DockerClient docker)
-      throws MojoExecutionException, DockerException, IOException, InterruptedException {
+      throws MojoExecutionException, DockerException, InterruptedException {
     final String[] imageNameParts = parseImageName(imageName);
     if (imageTags == null) {
-      imageTags = Collections.singletonList("");
+      imageTags = new ArrayList<>(1);
+      imageTags.add(imageNameParts[1]);
     } else if (removeAllTags) {
-        getLog().info("Removal of all tags requested, searching for tags");
-        // removal of all tags requested, loop over all images to find tags
-        for (final Image currImage : docker.listImages()) {
-            getLog().debug("Found image: " + currImage.toString());
-            String[] parsedRepoTag;
-            for (final String repoTag : currImage.repoTags()) {
-                parsedRepoTag = parseImageName(repoTag);
-                // if repo name matches imageName then save the tag for deletion
-                if (parsedRepoTag[0].equals(imageNameParts)) {
-                    imageTags.add(parsedRepoTag[1]);
-                    getLog().info("Adding tag for removal: " + parsedRepoTag[1]);
-                }
-            }
+      getLog().info("Removal of all tags requested, searching for tags");
+      // removal of all tags requested, loop over all images to find tags
+      for (final Image currImage : docker.listImages()) {
+        getLog().debug("Found image: " + currImage.toString());
+        String[] parsedRepoTag;
+        for (final String repoTag : currImage.repoTags()) {
+          parsedRepoTag = parseImageName(repoTag);
+          // if repo name matches imageName then save the tag for deletion
+          if (parsedRepoTag[0].equals(imageNameParts[0])) {
+            imageTags.add(parsedRepoTag[1]);
+            getLog().info("Adding tag for removal: " + parsedRepoTag[1]);
+          }
         }
+      }
     }
     imageTags.add(imageNameParts[1]);
 
     for (final String imageTag : imageTags) {
-      final String currImageName = imageNameParts[0] +
-                             ((isNullOrEmpty(imageTag)) ? "" : (":" + imageTag));
+      final String currImageName =
+          imageNameParts[0] + ((isNullOrEmpty(imageTag)) ? "" : (":" + imageTag));
       getLog().info("Removing -f " + currImageName);
 
       try {

--- a/src/main/java/com/spotify/docker/RemoveImageMojo.java
+++ b/src/main/java/com/spotify/docker/RemoveImageMojo.java
@@ -32,7 +32,9 @@ import com.spotify.docker.client.messages.RemovedImage;
 import com.spotify.docker.client.shaded.javax.ws.rs.NotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -86,7 +88,8 @@ public class RemoveImageMojo extends AbstractDockerMojo {
     }
     imageTags.add(imageNameParts[1]);
 
-    for (final String imageTag : imageTags) {
+    final Set<String> uniqueImageTags = new HashSet<>(imageTags);
+    for (final String imageTag : uniqueImageTags) {
       final String currImageName =
           imageNameParts[0] + ((isNullOrEmpty(imageTag)) ? "" : (":" + imageTag));
       getLog().info("Removing -f " + currImageName);

--- a/src/main/java/com/spotify/docker/RemoveImageMojo.java
+++ b/src/main/java/com/spotify/docker/RemoveImageMojo.java
@@ -65,10 +65,10 @@ public class RemoveImageMojo extends AbstractDockerMojo {
       imageTags = new ArrayList<>(1);
     } else if (imageTags.size() == 1 && imageTags.get(0).equals("*")) {
         // removal of all tags requested, loop over all images to find tags
-        for (Image currImage : docker.listImages()) {
+        for (final Image currImage : docker.listImages()) {
             getLog().debug("Found image: " + currImage.toString());
             String[] parsedRepoTag;
-            for (String repoTag : currImage.repoTags()) {
+            for (final String repoTag : currImage.repoTags()) {
                 parsedRepoTag = parseImageName(repoTag);
                 // if repo name matches imageName then save the tag for deletion
                 if (parsedRepoTag[0].equals(imageNameParts)) {

--- a/src/main/java/com/spotify/docker/RemoveImageMojo.java
+++ b/src/main/java/com/spotify/docker/RemoveImageMojo.java
@@ -59,13 +59,13 @@ public class RemoveImageMojo extends AbstractDockerMojo {
   @Override
   protected void execute(final DockerClient docker)
       throws MojoExecutionException, DockerException, IOException, InterruptedException {
-    final String imageNameWithoutTag = parseImageName(imageName)[0];
+    final String[] imageNameParts = parseImageName(imageName);
     if (imageTags == null) {
-      imageTags = Collections.singletonList("");
+      imageTags = Collections.singletonList(imageNameParts[1]);
     }
 
     for (final String imageTag : imageTags) {
-      final String currImageName = imageNameWithoutTag +
+      final String currImageName = imageNameParts[0] +
                              ((isNullOrEmpty(imageTag)) ? "" : (":" + imageTag));
       getLog().info("Removing -f " + currImageName);
 

--- a/src/main/java/com/spotify/docker/RemoveImageMojo.java
+++ b/src/main/java/com/spotify/docker/RemoveImageMojo.java
@@ -32,7 +32,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.IOException;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -51,7 +51,7 @@ public class RemoveImageMojo extends AbstractDockerMojo {
   private String imageName;
 
   /**
-   * Additional tags to tag the image with.
+   * Additional tags to remove.
    */
   @Parameter(property = "dockerImageTags")
   private List<String> imageTags;
@@ -60,9 +60,10 @@ public class RemoveImageMojo extends AbstractDockerMojo {
   protected void execute(final DockerClient docker)
       throws MojoExecutionException, DockerException, IOException, InterruptedException {
     final String[] imageNameParts = parseImageName(imageName);
-    if (imageTags == null || imageTags.isEmpty()) {
-      imageTags = Collections.singletonList(imageNameParts[1]);
+    if (imageTags == null) {
+      imageTags = new ArrayList<>(1);
     }
+    imageTags.add(imageNameParts[1]);
 
     for (final String imageTag : imageTags) {
       final String currImageName = imageNameParts[0] +

--- a/src/main/java/com/spotify/docker/RemoveImageMojo.java
+++ b/src/main/java/com/spotify/docker/RemoveImageMojo.java
@@ -60,7 +60,7 @@ public class RemoveImageMojo extends AbstractDockerMojo {
   protected void execute(final DockerClient docker)
       throws MojoExecutionException, DockerException, IOException, InterruptedException {
     final String[] imageNameParts = parseImageName(imageName);
-    if (imageTags == null) {
+    if (imageTags == null || imageTags.isEmpty()) {
       imageTags = Collections.singletonList(imageNameParts[1]);
     }
 


### PR DESCRIPTION
Related to issue #179. This adds support for specifying _-DremoveTags="*"_ to remove all tags of a given image, and includes an IT project. The primary use case for this is to run `mvn docker:removeImage -DdockerImageTags="*"` at the end of a CI build to ensure that an image which failed validation and thus wasn't published to the registry is not unwittingly exposed to subsequent builds on

Rebased version of https://github.com/spotify/docker-maven-plugin/pull/228
