### PR TITLE
Drop support for Java 7; add support for Java 9-11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,18 @@ services:
 
 language: java
 
-jdk:
-  - openjdk8
-  - openjdk9
-  - openjdk10
-  - openjdk11
+matrix:
+  include:
+    - jdk: openjdk8
+    - jdk: openjdk9
+      before_install:
+        - rm "${JAVA_HOME}/lib/security/cacerts"
+        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
+    - jdk: openjdk10
+      before_install:
+        - rm "${JAVA_HOME}/lib/security/cacerts"
+        - ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"
+    - jdk: openjdk11
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,10 @@ services:
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
+  - openjdk9
+  - openjdk10
+  - openjdk11
 
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.2.0 (release TBD)
+
+* Support Java 9, 10, and 11.
+* Fix an ExceptionInInitializerError when plugin is used on Java 11 ([401][])
+
+  [401]: https://github.com/spotify/docker-maven-plugin/issues/401
+
 ## 1.0.0
 
 ### Revamped authentication support

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.spotify</groupId>
   <artifactId>docker-maven-plugin</artifactId>
-  <version>1.1.2-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
   <name>docker-maven-plugin</name>
   <description>A maven plugin for docker</description>
@@ -133,7 +133,7 @@
     <dependency>
       <groupId>com.spotify</groupId>
       <artifactId>docker-client</artifactId>
-      <version>8.11.4</version>
+      <version>8.14.1</version>
       <classifier>shaded</classifier>
     </dependency>
     <dependency>
@@ -273,8 +273,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
@@ -374,7 +374,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>3.0.1</version>
         <configuration>
           <show>private</show>
           <failOnError>false</failOnError>

--- a/src/it/extra-tags/pom.xml
+++ b/src/it/extra-tags/pom.xml
@@ -11,6 +11,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <build>

--- a/src/it/parallel-modules/a/pom.xml
+++ b/src/it/parallel-modules/a/pom.xml
@@ -12,6 +12,12 @@
   <artifactId>parallel-modules-a</artifactId>
   <packaging>docker</packaging>
 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
   <build>
     <plugins>
       <plugin>

--- a/src/it/parallel-modules/b/pom.xml
+++ b/src/it/parallel-modules/b/pom.xml
@@ -12,6 +12,12 @@
   <artifactId>parallel-modules-b</artifactId>
   <packaging>docker</packaging>
 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
   <build>
     <plugins>
       <plugin>

--- a/src/it/simple/pom.xml
+++ b/src/it/simple/pom.xml
@@ -11,6 +11,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <build>

--- a/src/it/using-legacy/pom.xml
+++ b/src/it/using-legacy/pom.xml
@@ -11,6 +11,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <build>

--- a/src/it/with-many-modules/a/pom.xml
+++ b/src/it/with-many-modules/a/pom.xml
@@ -12,6 +12,12 @@
   <artifactId>with-many-modules-a</artifactId>
   <packaging>docker</packaging>
 
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
   <build>
     <plugins>
       <plugin>

--- a/src/main/java/com/spotify/docker/AbstractDockerMojo.java
+++ b/src/main/java/com/spotify/docker/AbstractDockerMojo.java
@@ -199,7 +199,7 @@ abstract class AbstractDockerMojo extends AbstractMojo {
   /**
    * Get the email from the server configuration in <code>~/.m2/settings.xml</code>.
    *
-   * <pre>
+   * <pre>{@code
    * <servers>
    *   <server>
    *     <id>my-private-docker-registry</id>
@@ -209,10 +209,10 @@ abstract class AbstractDockerMojo extends AbstractMojo {
    *     </configuration>
    *   </server>
    * </servers>
-   * </pre>
+   * }</pre>
    *
    * The above <code>settings.xml</code> would return "foo@bar.com".
-   *
+   * @param server {@link Server}
    * @return email, or {@code null} if not set
    */
   private String getEmail(final Server server) {
@@ -233,6 +233,8 @@ abstract class AbstractDockerMojo extends AbstractMojo {
 
   /**
    * Builds the registryAuth object from server details.
+   * @return {@link RegistryAuth}
+   * @throws MojoExecutionException
    */
   protected RegistryAuth registryAuth() throws MojoExecutionException {
     if (settings != null && serverId != null) {

--- a/src/main/java/com/spotify/docker/BuildMojo.java
+++ b/src/main/java/com/spotify/docker/BuildMojo.java
@@ -213,9 +213,9 @@ public class BuildMojo extends AbstractDockerMojo {
 
   /**
    * If specified as true, a tag will be generated consisting of the first 7 characters of the most
-   * recent git commit ID, resulting in something like <tt>image:df8e8e6</tt>. If there are any
+   * recent git commit ID, resulting in something like {@code image:df8e8e6}. If there are any
    * changes not yet committed, the string '.DIRTY' will be appended to the end. Note, if a tag is
-   * explicitly specified in the <tt>newName</tt> parameter, this flag will be ignored.
+   * explicitly specified in the {@code newName} parameter, this flag will be ignored.
    */
   @Parameter(property = "useGitCommitId", defaultValue = "false")
   private boolean useGitCommitId;
@@ -223,10 +223,10 @@ public class BuildMojo extends AbstractDockerMojo {
   /**
    * Resources to include in the build. Specify resources by using the standard resource elements as
    * defined in the <a href="http://maven.apache.org/pom.html#Resources">resources</a> section in
-   * the pom reference. If dockerDirectory is not set, the <tt>targetPath</tt> value is the location
-   * in the container where the resource should be copied to. The value is relative to '<tt>/</tt>'
-   * in the container, and defaults to '<tt>.</tt>'. If dockerDirectory is set, <tt>targetPath</tt>
-   * is relative to the dockerDirectory, and defaults to '<tt>.</tt>'. In that case, the Dockerfile
+   * the pom reference. If dockerDirectory is not set, the {@code targetPath} value is the location
+   * in the container where the resource should be copied to. The value is relative to '{@code /}'
+   * in the container, and defaults to '{@code .}'. If dockerDirectory is set, {@code targetPath}
+   * is relative to the dockerDirectory, and defaults to '{@code .}'. In that case, the Dockerfile
    * can copy the resources into the container using the ADD instruction.
    */
   @Parameter(property = "dockerResources")

--- a/src/main/java/com/spotify/docker/CompositeImageName.java
+++ b/src/main/java/com/spotify/docker/CompositeImageName.java
@@ -41,9 +41,14 @@ class CompositeImageName {
   }
 
   /**
-   * An image name can be a plain image name or in the composite format &lt;name&gt;:&lt;tag&gt and
+   * An image name can be a plain image name or in the composite format &lt;name&gt;:&lt;tag&gt; and
    * this factory method makes sure that we get the plain image name as well as all the desired tags
    * for an image, including any composite tag.
+   *
+   * @param imageName Image name.
+   * @param imageTags List of image tags.
+   * @return {@link CompositeImageName}
+   * @throws MojoExecutionException
    */
   static CompositeImageName create(final String imageName, final List<String> imageTags)
       throws MojoExecutionException {

--- a/src/main/java/com/spotify/docker/TagMojo.java
+++ b/src/main/java/com/spotify/docker/TagMojo.java
@@ -38,7 +38,7 @@ import static com.spotify.docker.Utils.pushImage;
 import static com.spotify.docker.Utils.writeImageInfoFile;
 
 /**
- * Applies a tag to a docker image. Optionally, <tt>useGitCommitId</tt> can be used to generate a
+ * Applies a tag to a docker image. Optionally, {@code useGitCommitId} can be used to generate a
  * tag consisting of the first 7 characters of the most recent git commit ID.
  */
 @Mojo(name = "tag")
@@ -61,7 +61,7 @@ public class TagMojo extends AbstractDockerMojo {
   /**
    * The new name that will be applied to the source image. If a tag is not specified, the docker
    * daemon will automatically apply the tag 'latest' to the specified repo. Only a repo without a
-   * tag should be specified if <tt>useGitCommitId</tt> is set to true.
+   * tag should be specified if {@code useGitCommitId} is set to true.
    */
   @Parameter(property = "newName", required = true)
   private String newName;
@@ -80,9 +80,9 @@ public class TagMojo extends AbstractDockerMojo {
 
   /**
    * If specified as true, a tag will be generated consisting of the first 7 characters of the most
-   * recent git commit ID, resulting in something like <tt>image:df8e8e6</tt>. If there are any
+   * recent git commit ID, resulting in something like {@code image:df8e8e6}. If there are any
    * changes not yet committed, the string '.DIRTY' will be appended to the end. Note, if a tag is
-   * explicitly specified in the <tt>newName</tt> parameter, this flag will be ignored.
+   * explicitly specified in the {@code newName} parameter, this flag will be ignored.
    */
   @Parameter(property = "useGitCommitId", defaultValue = "false")
   private boolean useGitCommitId;


### PR DESCRIPTION
Upgrade plugins to be compatible with Java 11.
Fix javadocs that started to throw errors with upgraded plugins.