### PR TITLE
Upgrade jackson deps from 2.9.4 to 2.9.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,7 +182,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.2.3</version>
+      <version>2.9.7</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
to fix these remote code execution vulnerabilities:

* https://nvd.nist.gov/vuln/detail/CVE-2018-7489
* https://nvd.nist.gov/vuln/detail/CVE-2017-7525