### PR TITLE
Mark mojo as threadsafe

### DIFF
--- a/src/main/java/com/spotify/docker/PushMojo.java
+++ b/src/main/java/com/spotify/docker/PushMojo.java
@@ -36,7 +36,7 @@ import static com.spotify.docker.Utils.pushImage;
 /**
  * Pushes a docker image repository to the specified docker registry.
  */
-@Mojo(name = "push")
+@Mojo(name = "push", threadSafe = true)
 public class PushMojo extends AbstractDockerMojo {
 
   /** Name of image to push. */

--- a/src/main/java/com/spotify/docker/RemoveImageMojo.java
+++ b/src/main/java/com/spotify/docker/RemoveImageMojo.java
@@ -42,7 +42,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 /**
  * Removes a docker image.
  */
-@Mojo(name = "removeImage")
+@Mojo(name = "removeImage", threadSafe = true)
 public class RemoveImageMojo extends AbstractDockerMojo {
 
   /**

--- a/src/main/java/com/spotify/docker/TagMojo.java
+++ b/src/main/java/com/spotify/docker/TagMojo.java
@@ -41,7 +41,7 @@ import static com.spotify.docker.Utils.writeImageInfoFile;
  * Applies a tag to a docker image. Optionally, {@code useGitCommitId} can be used to generate a
  * tag consisting of the first 7 characters of the most recent git commit ID.
  */
-@Mojo(name = "tag")
+@Mojo(name = "tag", threadSafe = true)
 public class TagMojo extends AbstractDockerMojo {
 
   /**


### PR DESCRIPTION
*****************************************************************
* Your build is requesting parallel execution, but project      *
* contains the following plugin(s) that have goals not marked   *
* as @threadSafe to support parallel building.                  *
* While this /may/ work fine, please look for plugin updates    *
* and/or request plugins be made thread-safe.                   *
* If reporting an issue, report it against the plugin in        *
* question, not against maven-core                              *
*****************************************************************
The following goals are not marked @threadSafe in xxx-project:
com.spotify:docker-maven-plugin:1.2.1:push
com.spotify:docker-maven-plugin:1.2.1:tag
*****************************************************************